### PR TITLE
Fix the parameter --batch-size

### DIFF
--- a/mongo_connector/connector.py
+++ b/mongo_connector/connector.py
@@ -745,16 +745,16 @@ def get_config_options():
                     " but no doc manager.")
         else:
             if option.value is not None:
-                bulk_size = option.value[0].get(
-                    'bulkSize', constants.DEFAULT_MAX_BULK)
+                batch_size = option.value[0].get(
+                    'batchSize', constants.DEFAULT_MAX_BULK)
             else:
-                bulk_size = constants.DEFAULT_MAX_BULK
+                batch_size = constants.DEFAULT_MAX_BULK
             option.value = [{
                 'docManager': cli_values['doc_manager'],
                 'targetURL': cli_values['target_url'],
                 'uniqueKey': cli_values['unique_key'],
                 'autoCommitInterval': cli_values['auto_commit_interval'],
-                'bulkSize': bulk_size
+                'batchSize': batch_size
             }]
 
         if not option.value:
@@ -777,8 +777,8 @@ def get_config_options():
                 dm['autoCommitInterval'] = constants.DEFAULT_COMMIT_INTERVAL
             if not dm.get('args'):
                 dm['args'] = {}
-            if not dm.get('bulkSize'):
-                dm['bulkSize'] = constants.DEFAULT_MAX_BULK
+            if not dm.get('batchSize'):
+                dm['batchSize'] = constants.DEFAULT_MAX_BULK
 
             aci = dm['autoCommitInterval']
             if aci is not None and aci < 0:
@@ -810,7 +810,7 @@ def get_config_options():
             kwargs = {
                 'unique_key': dm['uniqueKey'],
                 'auto_commit_interval': dm['autoCommitInterval'],
-                'chunk_size': dm['bulkSize']
+                'chunk_size': dm['batchSize']
             }
             for k in dm['args']:
                 if k not in kwargs:


### PR DESCRIPTION
Hi,

The parameter --batch-size wasn't forwarded to the doc manager because of the usage of different name. I unified it with the name of the option parameter.

What do you think?

Thanks!