### PR TITLE
Fix replica set connections

### DIFF
--- a/mongo_connector/connector.py
+++ b/mongo_connector/connector.py
@@ -309,6 +309,7 @@ class Connector(threading.Thread):
                 time.sleep(1)
 
         else:       # sharded cluster
+            queryStr = self.address.split('?')[1]
             while self.can_run is True:
 
                 for shard_doc in main_conn['config']['shards'].find():
@@ -337,8 +338,9 @@ class Connector(threading.Thread):
                             dm.stop()
                         return
 
+                    address = 'mongodb://' + hosts + '/?' + queryStr
                     shard_conn = MongoClient(
-                        hosts, replicaSet=repl_set, tz_aware=self.tz_aware,
+                        address, replicaSet=repl_set, tz_aware=self.tz_aware,
                         **self.ssl_kwargs)
                     if self.auth_key is not None:
                         shard_conn['admin'].authenticate(self.auth_username, self.auth_key)

--- a/mongo_connector/connector.py
+++ b/mongo_connector/connector.py
@@ -34,6 +34,7 @@ from mongo_connector.command_helper import CommandHelper
 from mongo_connector.util import log_fatal_exceptions
 
 from pymongo import MongoClient
+from pymongo import MongoReplicaSetClient
 
 LOG = logging.getLogger(__name__)
 
@@ -280,7 +281,7 @@ class Connector(threading.Thread):
 
             # Establish a connection to the replica set as a whole
             main_conn.close()
-            main_conn = MongoClient(
+            main_conn = MongoReplicaSetClient(
                 self.address, replicaSet=is_master['setName'],
                 tz_aware=self.tz_aware, **self.ssl_kwargs)
             if self.auth_key is not None:
@@ -339,7 +340,7 @@ class Connector(threading.Thread):
                         return
 
                     address = 'mongodb://' + hosts + '/?' + queryStr
-                    shard_conn = MongoClient(
+                    shard_conn = MongoReplicaSetClient(
                         address, replicaSet=repl_set, tz_aware=self.tz_aware,
                         **self.ssl_kwargs)
                     if self.auth_key is not None:


### PR DESCRIPTION
A combination of not forwarding the connection string to sharded instances + using the wrong pymongo class to connect to mongo makes it impossible to properly provide read preferences to mongo.

MongoClient (in pymongo 2.x) assumes that the connected mongo instance is a standalone instance, which doesn't matter for the initial connection to the mongos/discovery instance, but is problematic for the replica set connection.

When specifying a read preference, it doesn't apply to the MongoClient connection, since they're standalone connections. If we were connected via mongos, that'd be no problem, since mongos would handle this, but we only use the mongos connection to get to the real instances and the standalone client just ignores the read preference.

By using MongoReplicaSetClient, we ensure that the pymongo properly throws on read preference errors and also properly switches between instances.

This should fix #314.