### PR TITLE
change tests use right doc manager, setup id fields appropriately

### DIFF
--- a/mongo_connector/constants.py
+++ b/mongo_connector/constants.py
@@ -43,3 +43,8 @@ DEFAULT_LOGFILE_BACKUPCOUNT = 7
 # The log format
 DEFAULT_LOG_FORMAT = (
     '%(asctime)s [%(levelname)s] %(name)s:%(lineno)d - %(message)s')
+
+# If a single meta collection is used, defines the default collection name
+DEFAULT_META_COLLECTION_NAME = "__oplog"
+# If a single meta collection is used, defines the default cap size
+DEFAULT_META_COLLECTION_CAP_SIZE = 5 * 1024 * 1024

--- a/mongo_connector/doc_managers/mongo_doc_manager.py
+++ b/mongo_connector/doc_managers/mongo_doc_manager.py
@@ -60,9 +60,37 @@ class DocManager(DocManagerBase):
             raise errors.ConnectionFailed("Failed to connect to MongoDB")
         self.namespace_set = kwargs.get("namespace_set")
         self.chunk_size = kwargs.get('chunk_size', constants.DEFAULT_MAX_BULK)
+        self.use_single_meta_collection = kwargs.get(
+                                        'use_single_meta_collection',
+                                        False)
+        self.meta_collection_name = kwargs.get(
+                                        'meta_collection_name',
+                                        constants.DEFAULT_META_COLLECTION_NAME)
+        self.meta_collection_cap_size = kwargs.get(
+                                    'meta_collection_cap_size',
+                                    constants.DEFAULT_META_COLLECTION_CAP_SIZE)
+        self.id_field = 'doc_id' if self.use_single_meta_collection else '_id'
+
+        """ create the meta collection as capped if a single meta collection
+            is preferred """
+        if self.use_single_meta_collection:
+            if self.meta_collection_name not in \
+                    self.mongo["__mongo_connector"].collection_names():
+                self.mongo["__mongo_connector"].create_collection(
+                    self.meta_collection_name,
+                    capped=True,
+                    size=self.meta_collection_cap_size)
+                self.mongo["__mongo_connector"][self.meta_collection_name].ensure_index(self.id_field)
+                self.mongo["__mongo_connector"][self.meta_collection_name].ensure_index([('ns', 1), ('_ts', 1)])
 
     def _db_and_collection(self, namespace):
         return namespace.split('.', 1)
+
+    def _get_meta_collection(self, namespace):
+        if self.use_single_meta_collection:
+            return self.meta_collection_name
+        else:
+            return namespace
 
     @wrap_exceptions
     def _namespaces(self):
@@ -126,9 +154,11 @@ class DocManager(DocManagerBase):
 
         """
         db, coll = self._db_and_collection(namespace)
-        
-        self.mongo["__mongo_connector"][namespace].save({
-            '_id': document_id,
+
+        meta_collection = self._get_meta_collection(namespace)
+
+        self.mongo["__mongo_connector"][meta_collection].save({
+            self.id_field: document_id,
             "_ts": timestamp,
             "ns": namespace
         })
@@ -146,8 +176,10 @@ class DocManager(DocManagerBase):
         """
         database, coll = self._db_and_collection(namespace)
 
-        self.mongo["__mongo_connector"][namespace].save({
-            '_id': doc['_id'],
+        meta_collection = self._get_meta_collection(namespace)
+
+        self.mongo["__mongo_connector"][meta_collection].save({
+            self.id_field : doc['_id'],
             "_ts": timestamp,
             "ns": namespace
         })
@@ -158,7 +190,8 @@ class DocManager(DocManagerBase):
         def iterate_chunks():
             dbname, collname = self._db_and_collection(namespace)
             collection = self.mongo[dbname][collname]
-            meta_collection = self.mongo['__mongo_connector'][namespace]
+            meta_collection_name = self._get_meta_collection(namespace)
+            meta_collection = self.mongo['__mongo_connector'][meta_collection_name]
             more_chunks = True
             while more_chunks:
                 bulk = collection.initialize_ordered_bulk_op()
@@ -168,8 +201,9 @@ class DocManager(DocManagerBase):
                         doc = next(docs)
                         selector = {'_id': doc['_id']}
                         bulk.find(selector).upsert().replace_one(doc)
-                        bulk_meta.find(selector).upsert().replace_one({
-                            '_id': doc['_id'],
+                        meta_selector = {self.id_field : doc['_id']}
+                        bulk_meta.find(meta_selector).upsert().replace_one({
+                            self.id_field : doc['_id'],
                             'ns': namespace,
                             '_ts': timestamp
                         })
@@ -198,8 +232,10 @@ class DocManager(DocManagerBase):
         """
         database, coll = self._db_and_collection(namespace)
 
-        doc2 = self.mongo['__mongo_connector'][namespace].find_and_modify(
-            {'_id': document_id}, remove=True)
+        meta_collection = self._get_meta_collection(namespace)
+
+        doc2 = self.mongo['__mongo_connector'][meta_collection].find_and_modify(
+            {self.id_field : document_id}, remove=True)
         if (doc2 and doc2.get('gridfs_id')):
             GridFS(self.mongo[database], coll).delete(doc2['gridfs_id'])
         else:
@@ -210,8 +246,11 @@ class DocManager(DocManagerBase):
         database, coll = self._db_and_collection(namespace)
 
         id = GridFS(self.mongo[database], coll).put(f, filename=f.filename)
-        self.mongo["__mongo_connector"][namespace].save({
-            '_id': f._id,
+
+        meta_collection = self._get_meta_collection(namespace)
+
+        self.mongo["__mongo_connector"][meta_collection].save({
+            self.id_field : f._id,
             '_ts': timestamp,
             'ns': namespace,
             'gridfs_id': id
@@ -222,9 +261,10 @@ class DocManager(DocManagerBase):
         """Called to query Mongo for documents in a time range.
         """
         for namespace in self._namespaces():
-            database, coll = self._db_and_collection(namespace)
-            for ts_ns_doc in self.mongo["__mongo_connector"][namespace].find(
-                {'_ts': {'$lte': end_ts,
+            meta_collection = self._get_meta_collection(namespace)
+            for ts_ns_doc in self.mongo["__mongo_connector"][meta_collection].find(
+                {'ns': namespace,
+                 '_ts': {'$lte': end_ts,
                          '$gte': start_ts}}
             ):
                 yield ts_ns_doc
@@ -240,9 +280,9 @@ class DocManager(DocManagerBase):
         """
         def docs_by_ts():
             for namespace in self._namespaces():
-                database, coll = self._db_and_collection(namespace)
-                mc_coll = self.mongo["__mongo_connector"][namespace]
-                for ts_ns_doc in mc_coll.find(limit=1).sort('_ts', -1):
+                meta_collection = self._get_meta_collection(namespace)
+                mc_coll = self.mongo["__mongo_connector"][meta_collection]
+                for ts_ns_doc in mc_coll.find({'ns':namespace},limit=1).sort('_ts', -1):
                     yield ts_ns_doc
 
         return max(docs_by_ts(), key=lambda x: x["_ts"])

--- a/tests/test_mongo.py
+++ b/tests/test_mongo.py
@@ -32,6 +32,8 @@ from tests.util import assert_soon
 
 
 class MongoTestCase(unittest.TestCase):
+    
+    use_single_meta_collection = False
 
     @classmethod
     def setUpClass(cls):
@@ -103,10 +105,6 @@ class TestMongo(MongoTestCase):
         self.conn.test.test.drop()
         self.conn.test.test.files.drop()
         self.conn.test.test.chunks.drop()
-
-        """ we will set this to False, as we are testing this mode 
-            in test_mongo_doc_manager """
-        self.use_single_meta_collection = False
 
         self.connector.start()
         assert_soon(lambda: len(self.connector.shard_set) > 0)

--- a/tests/test_mongo.py
+++ b/tests/test_mongo.py
@@ -104,6 +104,10 @@ class TestMongo(MongoTestCase):
         self.conn.test.test.files.drop()
         self.conn.test.test.chunks.drop()
 
+        """ we will set this to False, as we are testing this mode 
+            in test_mongo_doc_manager """
+        self.use_single_meta_collection = False
+
         self.connector.start()
         assert_soon(lambda: len(self.connector.shard_set) > 0)
         assert_soon(lambda: sum(1 for _ in self._search()) == 0)

--- a/tests/test_mongo.py
+++ b/tests/test_mongo.py
@@ -49,7 +49,11 @@ class MongoTestCase(unittest.TestCase):
             yield doc
 
         fs = GridFS(self.mongo_conn['test'], 'test')
-        for doc in self.mongo_conn['__mongo_connector']['test.test'].find():
+
+        collection_name = 'test.test'
+        if self.use_single_meta_collection:
+            collection_name = '__oplog'
+        for doc in self.mongo_conn['__mongo_connector'][collection_name].find():
             if doc.get('gridfs_id'):
                 for f in fs.find({'_id': doc['gridfs_id']}):
                     doc['filename'] = f.filename

--- a/tests/test_mongo_doc_manager.py
+++ b/tests/test_mongo_doc_manager.py
@@ -207,7 +207,7 @@ class TestMongoDocManager(MongoTestCase):
         results = list(self.choosy_docman.search(0, 49))
         self.assertEqual(len(results), 100)
         for r in results:
-            self.assertGreaterEqual(r['_id'], 0)
+            self.assertGreaterEqual(r[self.id_field], 0)
 
     def test_get_last_doc(self):
         """Insert documents, verify that get_last_doc() returns the one with

--- a/tests/test_mongo_doc_manager.py
+++ b/tests/test_mongo_doc_manager.py
@@ -29,6 +29,8 @@ from tests.test_mongo import MongoTestCase
 class TestMongoDocManager(MongoTestCase):
     """Test class for MongoDocManager
     """
+   
+    id_field = "_id"
 
     @classmethod
     def setUpClass(cls):
@@ -38,23 +40,10 @@ class TestMongoDocManager(MongoTestCase):
 
     def setUp(self):
        
-        """ setup instance variables for running doc manager test
-            using single meta collection or collection per namespace """
-        if type(self) is TestMongoDocManagerWithSingleMetaCollection:
-            self.use_single_meta_collection = True
-            self.id_field = 'doc_id'
-            self.choosy_docman = DocManager(
+        self.choosy_docman = DocManager(
                 self.standalone.uri,
                 namespace_set=self.namespaces_inc,
-                use_single_meta_collection=True
-            )
-        else:
-            self.use_single_meta_collection = False
-            self.id_field = '_id'
-            self.choosy_docman = DocManager(
-                self.standalone.uri,
-                namespace_set=self.namespaces_inc
-            )
+                use_single_meta_collection=self.use_single_meta_collection)
 
         """Empty Mongo at the start of every test
         """
@@ -287,7 +276,12 @@ class TestMongoDocManager(MongoTestCase):
             self.mongo_conn.drop_database('test')
 
 class TestMongoDocManagerWithSingleMetaCollection(TestMongoDocManager):
-    pass
+    """ _id field has to be unique so we let that auto increment 
+        since we will be writing data from different namespaces into
+        single collection, hence we will use a different field for 
+        storing the document id"""
+    id_field = "doc_id"
+    use_single_meta_collection = True
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_mongo_doc_manager.py
+++ b/tests/test_mongo_doc_manager.py
@@ -35,15 +35,29 @@ class TestMongoDocManager(MongoTestCase):
         MongoTestCase.setUpClass()
         cls.namespaces_inc = ["test.test_include1", "test.test_include2"]
         cls.namespaces_exc = ["test.test_exclude1", "test.test_exclude2"]
-        cls.choosy_docman = DocManager(
-            cls.standalone.uri,
-            namespace_set=TestMongoDocManager.namespaces_inc
-        )
 
     def setUp(self):
+       
+        """ setup instance variables for running doc manager test
+            using single meta collection or collection per namespace """
+        if type(self) is TestMongoDocManagerWithSingleMetaCollection:
+            self.use_single_meta_collection = True
+            self.id_field = 'doc_id'
+            self.choosy_docman = DocManager(
+                self.standalone.uri,
+                namespace_set=self.namespaces_inc,
+                use_single_meta_collection=True
+            )
+        else:
+            self.use_single_meta_collection = False
+            self.id_field = '_id'
+            self.choosy_docman = DocManager(
+                self.standalone.uri,
+                namespace_set=self.namespaces_inc
+            )
+
         """Empty Mongo at the start of every test
         """
-
         self.mongo_conn.drop_database("__mongo_connector")
         self._remove()
 
@@ -82,7 +96,7 @@ class TestMongoDocManager(MongoTestCase):
         """
 
         docc = {'_id': '1', 'name': 'John'}
-        self.mongo_doc.upsert(docc, *TESTARGS)
+        self.choosy_docman.upsert(docc, *TESTARGS)
         res = list(self._search())
         self.assertEqual(len(res), 1)
         for doc in res:
@@ -90,7 +104,7 @@ class TestMongoDocManager(MongoTestCase):
             self.assertEqual(doc['name'], 'John')
 
         docc = {'_id': '1', 'name': 'Paul'}
-        self.mongo_doc.upsert(docc, *TESTARGS)
+        self.choosy_docman.upsert(docc, *TESTARGS)
         res = list(self._search())
         self.assertEqual(len(res), 1)
         for doc in res:
@@ -100,14 +114,14 @@ class TestMongoDocManager(MongoTestCase):
     def test_bulk_upsert(self):
         """Test the bulk_upsert method."""
         docs = ({"_id": i} for i in range(1000))
-        self.mongo_doc.bulk_upsert(docs, *TESTARGS)
+        self.choosy_docman.bulk_upsert(docs, *TESTARGS)
         res = list(self._search(sort=[('_id', 1)]))
         self.assertEqual(len(res), 1000)
         for i, r in enumerate(res):
             self.assertEqual(r['_id'], i)
 
         docs = ({"_id": i, "weight": 2*i} for i in range(1000))
-        self.mongo_doc.bulk_upsert(docs, *TESTARGS)
+        self.choosy_docman.bulk_upsert(docs, *TESTARGS)
 
         res = list(self._search(sort=[('_id', 1)]))
         self.assertEqual(len(res), 1000)
@@ -119,14 +133,14 @@ class TestMongoDocManager(MongoTestCase):
         """
 
         docc = {'_id': '1', 'name': 'John'}
-        self.mongo_doc.upsert(docc, *TESTARGS)
+        self.choosy_docman.upsert(docc, *TESTARGS)
         self.assertEqual(len(list(self._search())), 1)
-        self.mongo_doc.remove(docc['_id'], *TESTARGS)
+        self.choosy_docman.remove(docc['_id'], *TESTARGS)
         self.assertEqual(len(list(self._search())), 0)
 
     def test_insert_file(self):
         # Drop database, so that mongo_doc's client refreshes its index cache.
-        self.mongo_doc.mongo.drop_database('test')
+        self.choosy_docman.mongo.drop_database('test')
         test_data = ' '.join(str(x) for x in range(100000)).encode('utf8')
         docc = {
             '_id': 'test_id',
@@ -134,16 +148,16 @@ class TestMongoDocManager(MongoTestCase):
             'upload_date': 5,
             'md5': 'test_md5'
         }
-        self.mongo_doc.insert_file(MockGridFSFile(docc, test_data), *TESTARGS)
+        self.choosy_docman.insert_file(MockGridFSFile(docc, test_data), *TESTARGS)
         res = self._search()
         for doc in res:
-            self.assertEqual(doc['_id'], docc['_id'])
+            self.assertEqual(doc[self.id_field], docc['_id'])
             self.assertEqual(doc['filename'], docc['filename'])
             self.assertEqual(doc['content'], test_data)
 
     def test_remove_file(self):
         # Drop database, so that mongo_doc's client refreshes its index cache.
-        self.mongo_doc.mongo.drop_database('test')
+        self.choosy_docman.mongo.drop_database('test')
         test_data = b'hello world'
         docc = {
             '_id': 'test_id',
@@ -152,11 +166,11 @@ class TestMongoDocManager(MongoTestCase):
             'md5': 'test_md5'
         }
 
-        self.mongo_doc.insert_file(MockGridFSFile(docc, test_data), *TESTARGS)
+        self.choosy_docman.insert_file(MockGridFSFile(docc, test_data), *TESTARGS)
         res = list(self._search())
         self.assertEqual(len(res), 1)
 
-        self.mongo_doc.remove(docc['_id'], *TESTARGS)
+        self.choosy_docman.remove(docc['_id'], *TESTARGS)
         res = list(self._search())
         self.assertEqual(len(res), 0)
 
@@ -167,15 +181,15 @@ class TestMongoDocManager(MongoTestCase):
         """
 
         docc = {'_id': '1', 'name': 'John'}
-        self.mongo_doc.upsert(docc, 'test.test', 5767301236327972865)
+        self.choosy_docman.upsert(docc, 'test.test_include1', 5767301236327972865)
         docc2 = {'_id': '2', 'name': 'John Paul'}
-        self.mongo_doc.upsert(docc2, 'test.test', 5767301236327972866)
+        self.choosy_docman.upsert(docc2, 'test.test_include1', 5767301236327972866)
         docc3 = {'_id': '3', 'name': 'Paul'}
-        self.mongo_doc.upsert(docc3, 'test.test', 5767301236327972870)
-        search = list(self.mongo_doc.search(5767301236327972865,
+        self.choosy_docman.upsert(docc3, 'test.test_include1', 5767301236327972870)
+        search = list(self.choosy_docman.search(5767301236327972865,
                                             5767301236327972866))
         self.assertEqual(len(search), 2)
-        result_id = [result.get("_id") for result in search]
+        result_id = [result.get(self.id_field) for result in search]
         self.assertIn('1', result_id)
         self.assertIn('2', result_id)
 
@@ -200,17 +214,17 @@ class TestMongoDocManager(MongoTestCase):
             the latest timestamp.
         """
         docc = {'_id': '4', 'name': 'Hare'}
-        self.mongo_doc.upsert(docc, 'test.test', 3)
+        self.choosy_docman.upsert(docc, 'test.test_include1', 3)
         docc = {'_id': '5', 'name': 'Tortoise'}
-        self.mongo_doc.upsert(docc, 'test.test', 2)
+        self.choosy_docman.upsert(docc, 'test.test_include1', 2)
         docc = {'_id': '6', 'name': 'Mr T.'}
-        self.mongo_doc.upsert(docc, 'test.test', 1)
-        doc = self.mongo_doc.get_last_doc()
-        self.assertEqual(doc['_id'], '4')
+        self.choosy_docman.upsert(docc, 'test.test_include1', 1)
+        doc = self.choosy_docman.get_last_doc()
+        self.assertEqual(doc[self.id_field], '4')
         docc = {'_id': '6', 'name': 'HareTwin'}
-        self.mongo_doc.upsert(docc, 'test.test', 4)
-        doc = self.mongo_doc.get_last_doc()
-        self.assertEqual(doc['_id'], '6')
+        self.choosy_docman.upsert(docc, 'test.test_include1', 4)
+        doc = self.choosy_docman.get_last_doc()
+        self.assertEqual(doc[self.id_field], '6')
 
     def test_get_last_doc_namespaces(self):
         """Ensure that get_last_doc returns the latest document in one of
@@ -223,20 +237,20 @@ class TestMongoDocManager(MongoTestCase):
             self.choosy_docman.upsert({"_id": i}, ns, i)
         last_doc = self.choosy_docman.get_last_doc()
         # Even value for _id means ns was in self.namespaces_inc.
-        self.assertEqual(last_doc["_id"], 98)
+        self.assertEqual(last_doc[self.id_field], 98)
 
         # remove latest document so last doc is in included namespace,
         # shouldn't change result
         db, coll = self.namespaces_inc[0].split(".", 1)
         self.standalone.client()[db][coll].remove({"_id": 99})
         last_doc = self.choosy_docman.get_last_doc()
-        self.assertEqual(last_doc["_id"], 98)
+        self.assertEqual(last_doc[self.id_field], 98)
 
     def test_commands(self):
         # Also test with namespace mapping.
         # Note that mongo-connector does not currently support commands after
         # renaming a database.
-        self.mongo_doc.command_helper = CommandHelper(
+        self.choosy_docman.command_helper = CommandHelper(
             namespace_set=['test.test', 'test.test2', 'test.drop'],
             dest_mapping={
                 'test.test': 'test.othertest',
@@ -244,10 +258,10 @@ class TestMongoDocManager(MongoTestCase):
             })
 
         try:
-            self.mongo_doc.handle_command({'create': 'test'}, *TESTARGS)
+            self.choosy_docman.handle_command({'create': 'test'}, *TESTARGS)
             self.assertIn('othertest',
                           self.mongo_conn['test'].collection_names())
-            self.mongo_doc.handle_command(
+            self.choosy_docman.handle_command(
                 {'renameCollection': 'test.test', 'to': 'test.test2'},
                 'admin.$cmd', 1)
             self.assertNotIn('othertest',
@@ -255,23 +269,25 @@ class TestMongoDocManager(MongoTestCase):
             self.assertIn('test2',
                           self.mongo_conn['test'].collection_names())
 
-            self.mongo_doc.handle_command(
+            self.choosy_docman.handle_command(
                 {'drop': 'test2'}, 'test.$cmd', 1)
             self.assertNotIn('test2',
                              self.mongo_conn['test'].collection_names())
 
             self.assertIn('test', self.mongo_conn.database_names())
-            self.mongo_doc.handle_command({'dropDatabase': 1}, 'test.$cmd', 1)
+            self.choosy_docman.handle_command({'dropDatabase': 1}, 'test.$cmd', 1)
             self.assertNotIn('test', self.mongo_conn.database_names())
 
             # Briefly test mapped database name with dropDatabase command.
             self.mongo_conn.dropped.collection.insert({'a': 1})
             self.assertIn('dropped', self.mongo_conn.database_names())
-            self.mongo_doc.handle_command({'dropDatabase': 1}, 'test.$cmd', 1)
+            self.choosy_docman.handle_command({'dropDatabase': 1}, 'test.$cmd', 1)
             self.assertNotIn('dropped', self.mongo_conn.database_names())
         finally:
             self.mongo_conn.drop_database('test')
 
+class TestMongoDocManagerWithSingleMetaCollection(TestMongoDocManager):
+    pass
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_mongo_doc_manager.py
+++ b/tests/test_mongo_doc_manager.py
@@ -29,7 +29,7 @@ from tests.test_mongo import MongoTestCase
 class TestMongoDocManager(MongoTestCase):
     """Test class for MongoDocManager
     """
-   
+
     id_field = "_id"
 
     @classmethod
@@ -39,11 +39,11 @@ class TestMongoDocManager(MongoTestCase):
         cls.namespaces_exc = ["test.test_exclude1", "test.test_exclude2"]
 
     def setUp(self):
-       
+
         self.choosy_docman = DocManager(
-                self.standalone.uri,
-                namespace_set=self.namespaces_inc,
-                use_single_meta_collection=self.use_single_meta_collection)
+            self.standalone.uri,
+            namespace_set=self.namespaces_inc,
+            use_single_meta_collection=self.use_single_meta_collection)
 
         """Empty Mongo at the start of every test
         """
@@ -109,13 +109,13 @@ class TestMongoDocManager(MongoTestCase):
         for i, r in enumerate(res):
             self.assertEqual(r['_id'], i)
 
-        docs = ({"_id": i, "weight": 2*i} for i in range(1000))
+        docs = ({"_id": i, "weight": 2 * i} for i in range(1000))
         self.choosy_docman.bulk_upsert(docs, *TESTARGS)
 
         res = list(self._search(sort=[('_id', 1)]))
         self.assertEqual(len(res), 1000)
         for i, r in enumerate(res):
-            self.assertEqual(r['weight'], 2*i)
+            self.assertEqual(r['weight'], 2 * i)
 
     def test_remove(self):
         """Ensure we can properly delete from Mongo via DocManager.
@@ -137,7 +137,8 @@ class TestMongoDocManager(MongoTestCase):
             'upload_date': 5,
             'md5': 'test_md5'
         }
-        self.choosy_docman.insert_file(MockGridFSFile(docc, test_data), *TESTARGS)
+        self.choosy_docman.insert_file(
+            MockGridFSFile(docc, test_data), *TESTARGS)
         res = self._search()
         for doc in res:
             self.assertEqual(doc[self.id_field], docc['_id'])
@@ -155,7 +156,8 @@ class TestMongoDocManager(MongoTestCase):
             'md5': 'test_md5'
         }
 
-        self.choosy_docman.insert_file(MockGridFSFile(docc, test_data), *TESTARGS)
+        self.choosy_docman.insert_file(
+            MockGridFSFile(docc, test_data), *TESTARGS)
         res = list(self._search())
         self.assertEqual(len(res), 1)
 
@@ -170,13 +172,16 @@ class TestMongoDocManager(MongoTestCase):
         """
 
         docc = {'_id': '1', 'name': 'John'}
-        self.choosy_docman.upsert(docc, 'test.test_include1', 5767301236327972865)
+        self.choosy_docman.upsert(
+            docc, 'test.test_include1', 5767301236327972865)
         docc2 = {'_id': '2', 'name': 'John Paul'}
-        self.choosy_docman.upsert(docc2, 'test.test_include1', 5767301236327972866)
+        self.choosy_docman.upsert(
+            docc2, 'test.test_include1', 5767301236327972866)
         docc3 = {'_id': '3', 'name': 'Paul'}
-        self.choosy_docman.upsert(docc3, 'test.test_include1', 5767301236327972870)
+        self.choosy_docman.upsert(
+            docc3, 'test.test_include1', 5767301236327972870)
         search = list(self.choosy_docman.search(5767301236327972865,
-                                            5767301236327972866))
+                                                5767301236327972866))
         self.assertEqual(len(search), 2)
         result_id = [result.get(self.id_field) for result in search]
         self.assertIn('1', result_id)
@@ -264,16 +269,19 @@ class TestMongoDocManager(MongoTestCase):
                              self.mongo_conn['test'].collection_names())
 
             self.assertIn('test', self.mongo_conn.database_names())
-            self.choosy_docman.handle_command({'dropDatabase': 1}, 'test.$cmd', 1)
+            self.choosy_docman.handle_command(
+                {'dropDatabase': 1}, 'test.$cmd', 1)
             self.assertNotIn('test', self.mongo_conn.database_names())
 
             # Briefly test mapped database name with dropDatabase command.
             self.mongo_conn.dropped.collection.insert({'a': 1})
             self.assertIn('dropped', self.mongo_conn.database_names())
-            self.choosy_docman.handle_command({'dropDatabase': 1}, 'test.$cmd', 1)
+            self.choosy_docman.handle_command(
+                {'dropDatabase': 1}, 'test.$cmd', 1)
             self.assertNotIn('dropped', self.mongo_conn.database_names())
         finally:
             self.mongo_conn.drop_database('test')
+
 
 class TestMongoDocManagerWithSingleMetaCollection(TestMongoDocManager):
     """ _id field has to be unique so we let that auto increment 


### PR DESCRIPTION
Support for using a single meta collection
1. Added Support for using a single meta collection which will be a capped collection. This size can be given using the configuration options.
2. Change mongo_doc_manager test case to use the proper doc manager and also support running the tests with single meta collection.
3. As part of using single meta collection, _id field cannot be used in meta collection as there can be duplicates, create a different field (doc_id) which will capture the id of the original document.