### PR TITLE
add sentry to the supported logging methods

### DIFF
--- a/config.json
+++ b/config.json
@@ -8,6 +8,7 @@
     "batchSize": -1,
     "verbosity": 0,
     "continueOnError": false,
+    "skipCount": false,
 
     "logging": {
         "type": "file",

--- a/mongo_connector/connector.py
+++ b/mongo_connector/connector.py
@@ -151,6 +151,7 @@ class Connector(threading.Thread):
             collection_dump=(not config['noDump']),
             batch_size=config['batchSize'],
             continue_on_error=config['continueOnError'],
+            skip_count=config['skipCount'],
             auth_username=config['authentication.adminUsername'],
             auth_key=auth_key,
             fields=config['fields'],
@@ -969,6 +970,19 @@ def get_config_options():
         "Note: Applying oplog operations to an incomplete"
         " set of documents due to errors may cause undefined"
         " behavior. Use this flag to dump only.")
+
+    skip_count = add_option(
+        config_key="skipCount",
+        default=False,
+        type=bool)
+
+    skip_count.add_cli(
+        "--skip-count", dest="skip_count",
+        help="Skip logging the count of operations found in"
+             " the oplog cursor. This count is only calculated"
+             " when a cursor is created, but is potentially very"
+             " expensive and slow.")
+
 
     config_file = add_option()
     config_file.add_cli(

--- a/mongo_connector/connector.py
+++ b/mongo_connector/connector.py
@@ -1018,8 +1018,15 @@ def setup_logging(conf):
         print("Logging to system log at %s" % conf['logging.host'])
     elif conf['logging.type'] == 'stream':
         log_out = logging.StreamHandler()
+    elif conf['logging.type'] == 'sentry':
+        try:
+            from raven.handlers.logging import SentryHandler
+        except Exception:
+            print("Could not import the Raven library to set up a Sentry client.")
+            sys.exit(1)
+        log_out = SentryHandler(conf['logging.dsn'])
     else:
-        print("Logging type must be one of 'stream', 'syslog', or 'file', not "
+        print("Logging type must be one of 'stream', 'syslog', 'file', or 'sentry', not "
               "'%s'." % conf['logging.type'])
         sys.exit(1)
 

--- a/setup.py
+++ b/setup.py
@@ -124,7 +124,8 @@ setup(name='mongo-connector',
       classifiers=filter(None, classifiers.split("\n")),
       install_requires=['pymongo >= 2.7.2, < 3.0.0',
                         'pysolr >= 3.1.0',
-                        'elasticsearch >= 1.2, < 2.0.0'],
+                        'elasticsearch >= 1.2, < 2.0.0',
+                        'raven >= 5.8.1'],
       packages=["mongo_connector", "mongo_connector.doc_managers"],
       package_data={
           'mongo_connector.doc_managers': ['schema.xml']

--- a/tests/test_sentry.py
+++ b/tests/test_sentry.py
@@ -1,0 +1,93 @@
+import json
+import logging
+import os
+import sys
+
+from mongo_connector import config
+from mongo_connector.connector import get_config_options, setup_logging
+from tests import unittest
+from raven.handlers.logging import SentryHandler
+
+__author__ = 'oxymor0n'
+
+sys.path[0:0] = [""]
+from_here = lambda *paths: os.path.join(
+    os.path.abspath(os.path.dirname(__file__)), *paths)
+
+SENTRY_DSN = "https://b37500744ba24f549ceafa94f0d8e52f:c94be83e51ab442993dcda1f4443be60@app.getsentry.com/59495"
+
+
+class TestConnectorConfig(unittest.TestCase):
+    """Test creating a Connector from a Config."""
+
+    # Configuration where every option is set to a non-default value.
+    set_everything_config = {
+        "mainAddress": "localhost:12345",
+        "oplogFile": from_here("lib", "dummy.timestamp"),
+        "noDump": True,
+        "batchSize": 3,
+        "verbosity": 2,
+        "continueOnError": True,
+        "timezoneAware": True,
+
+        "logging": {
+            "type": "sentry",
+            "dsn": SENTRY_DSN,
+        },
+
+        "docManagers": [
+            {
+                "docManager": "doc_manager_simulator",
+                "targetURL": "localhost:12345",
+                "bulkSize": 500,
+                "uniqueKey": "id",
+                "autoCommitInterval": 10,
+                "args": {
+                    "key": "value",
+                    "clientOptions": {
+                        "foo": "bar"
+                    }
+                }
+            }
+        ]
+    }
+
+    def setUp(self):
+        self.config = config.Config(get_config_options())
+        # Remove all logging Handlers, since tests may create Handlers.
+        logger = logging.getLogger()
+        for handler in logger.handlers:
+            logger.removeHandler(handler)
+
+    def assertLoggerState(self):
+        """Assert that the logger has a valid Raven SentryHandler."""
+        # Test Logger options.
+        log_levels = [
+            logging.ERROR,
+            logging.WARNING,
+            logging.INFO,
+            logging.DEBUG
+        ]
+        test_logger = setup_logging(self.config)
+        self.assertEqual(
+            log_levels[self.config['verbosity']],
+            test_logger.level)
+        test_handlers = [
+            h for h in test_logger.handlers
+            if isinstance(h, SentryHandler)]
+        self.assertEqual(len(test_handlers), 1)
+        test_handler = test_handlers[0]
+        expected_handler = SentryHandler(SENTRY_DSN)
+        self.assertEqual(test_handler.client.remote.get_public_dsn(), expected_handler.client.remote.get_public_dsn())
+        test_logger.info("Hello, Sentry!")
+
+    def test_sentry_logger(self):
+        # Test Config with only a configuration file.
+        self.config.load_json(
+            json.dumps(self.set_everything_config))
+        self.config.parse_args(argv=[])
+        self.assertLoggerState()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
add the option to direct the log stream to Sentry, an open source log aggregation platform (see [their homepage](https://www.getsentry.com/) and [GitHub repository](https://github.com/getsentry/sentry))