### PR TITLE
Use replicaset-name as identifier in oplog-timestamp-file

### DIFF
--- a/mongo_connector/connector.py
+++ b/mongo_connector/connector.py
@@ -288,7 +288,7 @@ class Connector(threading.Thread):
 
             # non sharded configuration
             oplog = OplogThread(
-                main_conn, self.doc_managers, self.oplog_progress,
+                main_conn, is_master['setName'], self.doc_managers, self.oplog_progress,
                 **self.kwargs)
             self.shard_set[0] = oplog
             LOG.info('MongoConnector: Starting connection thread %s' %
@@ -343,7 +343,7 @@ class Connector(threading.Thread):
                     if self.auth_key is not None:
                         shard_conn['admin'].authenticate(self.auth_username, self.auth_key)
                     oplog = OplogThread(
-                        shard_conn, self.doc_managers, self.oplog_progress,
+                        shard_conn, repl_set, self.doc_managers, self.oplog_progress,
                         **self.kwargs)
                     self.shard_set[shard_id] = oplog
                     msg = "Starting connection thread"

--- a/mongo_connector/oplog_manager.py
+++ b/mongo_connector/oplog_manager.py
@@ -655,12 +655,16 @@ class OplogThread(threading.Thread):
     def read_last_checkpoint(self):
         """Read the last checkpoint from the oplog progress dictionary.
         """
+        oplog_str = str(self.oplog)
         ret_val = None
 
         with self.oplog_progress as oplog_prog:
             oplog_dict = oplog_prog.get_dict()
             if self.repl_set_name in oplog_dict.keys():
                 ret_val = oplog_dict[self.repl_set_name]
+            # legacy support
+            if oplog_str in oplog_dict.keys():
+                ret_val = oplog_dict[oplog_str]
 
         LOG.debug("OplogThread: reading last checkpoint as %s " %
                   str(ret_val))

--- a/mongo_connector/oplog_manager.py
+++ b/mongo_connector/oplog_manager.py
@@ -663,7 +663,7 @@ class OplogThread(threading.Thread):
             if self.repl_set_name in oplog_dict.keys():
                 ret_val = oplog_dict[self.repl_set_name]
             # legacy support
-            if oplog_str in oplog_dict.keys():
+            if retval == None and oplog_str in oplog_dict.keys():
                 ret_val = oplog_dict[oplog_str]
 
         LOG.debug("OplogThread: reading last checkpoint as %s " %

--- a/mongo_connector/oplog_manager.py
+++ b/mongo_connector/oplog_manager.py
@@ -39,7 +39,7 @@ class OplogThread(threading.Thread):
 
     Calls the appropriate method on DocManagers for each relevant oplog entry.
     """
-    def __init__(self, primary_client, doc_managers,
+    def __init__(self, primary_client, repl_set_name, doc_managers,
                  oplog_progress_dict, mongos_client=None, **kwargs):
         super(OplogThread, self).__init__()
 
@@ -47,6 +47,9 @@ class OplogThread(threading.Thread):
 
         # The connection to the primary for this replicaSet.
         self.primary_client = primary_client
+        
+        # The name of the replica set
+        self.repl_set_name = repl_set_name
 
         # The connection to the mongos, if there is one.
         self.mongos_client = mongos_client
@@ -643,7 +646,7 @@ class OplogThread(threading.Thread):
         if self.checkpoint is not None:
             with self.oplog_progress as oplog_prog:
                 oplog_dict = oplog_prog.get_dict()
-                oplog_dict[str(self.oplog)] = self.checkpoint
+                oplog_dict[self.repl_set_name] = self.checkpoint
                 LOG.debug("OplogThread: oplog checkpoint updated to %s" %
                           str(self.checkpoint))
         else:
@@ -652,13 +655,12 @@ class OplogThread(threading.Thread):
     def read_last_checkpoint(self):
         """Read the last checkpoint from the oplog progress dictionary.
         """
-        oplog_str = str(self.oplog)
         ret_val = None
 
         with self.oplog_progress as oplog_prog:
             oplog_dict = oplog_prog.get_dict()
-            if oplog_str in oplog_dict.keys():
-                ret_val = oplog_dict[oplog_str]
+            if self.repl_set_name in oplog_dict.keys():
+                ret_val = oplog_dict[self.repl_set_name]
 
         LOG.debug("OplogThread: reading last checkpoint as %s " %
                   str(ret_val))

--- a/mongo_connector/oplog_manager.py
+++ b/mongo_connector/oplog_manager.py
@@ -663,7 +663,7 @@ class OplogThread(threading.Thread):
             if self.repl_set_name in oplog_dict.keys():
                 ret_val = oplog_dict[self.repl_set_name]
             # legacy support
-            if retval == None and oplog_str in oplog_dict.keys():
+            if ret_val == None and oplog_str in oplog_dict.keys():
                 ret_val = oplog_dict[oplog_str]
 
         LOG.debug("OplogThread: reading last checkpoint as %s " %


### PR DESCRIPTION
Currently the list of hosts in a replicaset is used as an identifier in the oplog-timestamp-file. This works well as long as the members in a replica set do not change. If this is the case, mongo-connector gets confused and attempts an initial import (because it is not able to find a proper entry in the oplog-timestamp-file).
This PR provides a fix for that and has legacy-support for the old format included (read old/new name, write new name only).