### PR TITLE
Updating mongo-connector --help

### DIFF
--- a/mongo_connector/connector.py
+++ b/mongo_connector/connector.py
@@ -737,8 +737,8 @@ def get_config_options():
         "will be mapped respectively according to this "
         "comma-separated list. These lists must have "
         "equal length. The default is to use the identity "
-        "mapping. This is currently only implemented "
-        "for mongo-to-mongo connections.")
+        "mapping. This works for mongo-to-mongo as well as" 
+        "mongo-to-elasticsearch connections.")
 
     # --gridfs-set is the set of GridFS namespaces to consider
     namespaces.add_cli(


### PR DESCRIPTION
`mongo-connector --help` says that `-g DEST_NS_SET` can only be used it for `mongo-to-mongo` connections but I noticed that destination namespace can also be a mongo-to-elasticsearch type, where namespace would be of type "index-name.document-type".

    mongo-connector -m localhost:27017 -t http://localhost:9200 -o /opt/mongo-connector.oplog -d elastic_doc_manager -n test.dataset,new-test.dataset -g test-index.new-dataset,new-test-index.new-dataset

where `localhost:27017` is a mongodb instance and `localhost:9200` is an elasticseach instance.

When used like this, it will result in the creation of an index `test-index` and document type `new-dataset` corresponding to database `test` and collections `dataset`.
