### PR TITLE
log BulkWriteError in mongo_doc_manager

### DIFF
--- a/mongo_connector/doc_managers/mongo_doc_manager.py
+++ b/mongo_connector/doc_managers/mongo_doc_manager.py
@@ -238,6 +238,9 @@ class DocManager(DocManagerBase):
             except pymongo.errors.DuplicateKeyError as e:
                 LOG.warn('Continuing after DuplicateKeyError: '
                          + str(e))
+            except pymongo.errors.BulkWriteError as bwe:
+                LOG.error(bwe.details)
+                raise e
 
     @wrap_exceptions
     def remove(self, document_id, namespace, timestamp):


### PR DESCRIPTION
Log the BulkWriteError explicitly so users can debug what goes wrong during collection dump, avoiding the situation in #339 