### PR TITLE
Manually generate the key for the oplog file so that it is deterministic

### DIFF
--- a/mongo_connector/oplog_manager.py
+++ b/mongo_connector/oplog_manager.py
@@ -726,16 +726,31 @@ class OplogThread(threading.Thread):
         if self.checkpoint is not None:
             with self.oplog_progress as oplog_prog:
                 oplog_dict = oplog_prog.get_dict()
-                oplog_dict[str(self.oplog)] = self.checkpoint
+                oplog_dict[self._oplog_key()] = self.checkpoint
                 LOG.debug("OplogThread: oplog checkpoint updated to %s" %
                           str(self.checkpoint))
         else:
             LOG.debug("OplogThread: no checkpoint to update.")
 
+    def _oplog_key(self):
+        client = self.primary_client
+        host = [
+            '%s:%d' % (host, port)
+            for host, port in sorted(client._topology_settings.seeds)]
+
+        options = client._MongoClient__options._options
+        LOG.info(options)
+        tz_aware = options['tz_aware']
+        connect = options['connect']
+        authsource = options['authsource']
+        replicaset = options['replicaset']
+
+        return "Collection(Database(MongoClient(host={0}, document_class=dict, tz_aware={1}, connect={2}, replicaset='{3}', authsource='{4}'), 'local'), 'oplog.rs')".format(host, str(tz_aware), str(connect), str(replicaset), str(authsource))
+
     def read_last_checkpoint(self):
         """Read the last checkpoint from the oplog progress dictionary.
         """
-        oplog_str = str(self.oplog)
+        oplog_str = self._oplog_key()
         ret_val = None
 
         with self.oplog_progress as oplog_prog:
@@ -743,7 +758,7 @@ class OplogThread(threading.Thread):
             if oplog_str in oplog_dict.keys():
                 ret_val = oplog_dict[oplog_str]
 
-        LOG.debug("OplogThread: reading last checkpoint as %s " %
+        LOG.info("OplogThread: reading last checkpoint as %s " %
                   str(ret_val))
         return ret_val
 

--- a/mongo_connector/oplog_manager.py
+++ b/mongo_connector/oplog_manager.py
@@ -739,7 +739,6 @@ class OplogThread(threading.Thread):
             for host, port in sorted(client._topology_settings.seeds)]
 
         options = client._MongoClient__options._options
-        LOG.info(options)
         tz_aware = options['tz_aware']
         connect = options['connect']
         authsource = options['authsource']


### PR DESCRIPTION
Hi,

I detected an odd behavior on mongo-connector 2.3.0: I had a mongo-connector successfully complete a dump and start tailing the oplog. The problem happened when the process was restarted. It detected a file but it restarted the dump anyway. After debugging the issue, I realized that the way it detects previous progress files was non-deterministic.

mongo-connector stores in the oplog.ts file a json array with two values, a string representing the mongo cluster it is tailing and the timestamp it last processed in said cluster. The problem I detected happened because the generation of the first value, the key, is non deterministic. It uses `str` on the collection object that comes from pymongo, that representation is not stable, it uses a dictionary to generate that representation and the order of the keys is not stable.

In other words, the first time I run mongo-connector it created a file like this:
`["Collection(Database(MongoClient(host=['mongo1.example.com:27017', 'mongo2.example.com:27017'], document_class=dict, tz_aware=False, connect=True, replicaset='rs-example', authsource='admin'), 'local'), 'oplog.rs')", 6291993029825789971]`
but the second time, when trying to read the oplog file it generated a key like this:
`"Collection(Database(MongoClient(host=['mongo2.example.com:27017', 'mongo1.example.com:27017'], document_class=dict, tz_aware=False, connect=True, authsource='admin', replicaset='rs-example'), 'local'), 'oplog.rs')"`

Notice two things, the attributes `authsource` and `replicateset` are swapped *and* the order of the host array is reversed.

Relying on the string representation of an object of a third-party dependency doesn't seem stable. In this pull request I am manually generating the expected string so that it is both stable and backwards compatible. The implementation digs into the internals of MongoClient, but, as far as I can tell, no more that it did before this change. Also, note that I'm no python expert.

I'd suggest either the solution implemented in this PR or have the users provide a string in the configuration, like a name for the job, and use that as the key.