### PR TITLE
#383 & #402, #451 fixes for error handling and graceful process exit

### DIFF
--- a/mongo_connector/connector.py
+++ b/mongo_connector/connector.py
@@ -297,7 +297,7 @@ class Connector(threading.Thread):
             oplog.start()
 
             while self.can_run:
-                if not self.shard_set[0].running:
+                if not (self.shard_set[0].running and self.shard_set[0].is_alive()):
                     LOG.error("MongoConnector: OplogThread"
                               " %s unexpectedly stopped! Shutting down" %
                               (str(self.shard_set[0])))
@@ -315,7 +315,7 @@ class Connector(threading.Thread):
                 for shard_doc in main_conn['config']['shards'].find():
                     shard_id = shard_doc['_id']
                     if shard_id in self.shard_set:
-                        if not self.shard_set[shard_id].running:
+                        if not (self.shard_set[shard_id].running and self.shard_set[shard_id].is_alive()):
                             LOG.error("MongoConnector: OplogThread "
                                       "%s unexpectedly stopped! Shutting "
                                       "down" %

--- a/mongo_connector/util.py
+++ b/mongo_connector/util.py
@@ -32,7 +32,12 @@ def exception_wrapper(mapping):
                 return f(*args, **kwargs)
             except:
                 exc_type, exc_value, exc_tb = sys.exc_info()
-                new_type = mapping.get(exc_type)
+                new_type = None
+                for src_type, dest_type in mapping.iteritems():
+                    if issubclass(exc_type, src_type):
+                        new_type = dest_type
+                        break
+
                 if new_type is None:
                     raise
                 reraise(new_type, exc_value, exc_tb)


### PR DESCRIPTION
Addresses issues that various individuals have had with the process hanging after an error and failing to continue synchronizing after certain exceptions that should have been handled. 
The first part of this fix changes the exception_wrapper to check the class hierarchy of exceptions for wrapping.
The second part deals with the status checking of threads during the connector.py process loop, and adds a thread.is_alive() check to those threads, so that if they exit without cleaning up they can be joined and the process can exit cleanly.