### PR TITLE
Do not lose updates on docman operation failure

### DIFF
--- a/mongo_connector/errors.py
+++ b/mongo_connector/errors.py
@@ -26,7 +26,12 @@ class ConnectionFailed(MongoConnectorError):
 
 
 class OperationFailed(MongoConnectorError):
-    """Raised for failed commands on the destination database
+    """Raised for permanently failed commands on the destination database
+    """
+
+
+class TransientOperationFailed(MongoConnectorError):
+    """Raised for failed commands on the destination database. The command should be retried.
     """
 
 

--- a/mongo_connector/oplog_manager.py
+++ b/mongo_connector/oplog_manager.py
@@ -315,6 +315,10 @@ class OplogThread(threading.Thread):
                             LOG.exception(
                                 "Unable to process oplog document %r"
                                 % entry)
+                        except errors.TransientOperationFailed:
+                            LOG.exception(
+                                "Transient failure while processing oplog document %r"
+                                % entry)
                             cursor.close()
                             break
                         except errors.ConnectionFailed:
@@ -879,7 +883,7 @@ class OplogThread(threading.Thread):
                         remov_inc += 1
                         LOG.debug(
                             "OplogThread: Rollback, removed %r " % doc)
-                    except errors.OperationFailed:
+                    except (errors.OperationFailed, errors.TransientOperationFailed):
                         LOG.warning(
                             "Could not delete document during rollback: %r "
                             "This can happen if this document was already "
@@ -901,7 +905,7 @@ class OplogThread(threading.Thread):
                         dm.upsert(doc,
                                   self.dest_mapping.get(namespace, namespace),
                                   util.bson_ts_to_long(rollback_cutoff_ts))
-                    except errors.OperationFailed:
+                    except (errors.OperationFailed, errors.TransientOperationFailed):
                         fail_insert_inc += 1
                         LOG.exception("OplogThread: Rollback, Unable to "
                                       "insert %r" % doc)

--- a/mongo_connector/oplog_manager.py
+++ b/mongo_connector/oplog_manager.py
@@ -268,57 +268,61 @@ class OplogThread(threading.Thread):
                         # use namespace mapping if one exists
                         ns = self.dest_mapping.get(ns, ns)
                         timestamp = util.bson_ts_to_long(entry['ts'])
-                        for docman in self.doc_managers:
-                            try:
-                                LOG.debug("OplogThread: Operation for this "
-                                          "entry is %s" % str(operation))
+                        try:
+                            for docman in self.doc_managers:
+                                    LOG.debug("OplogThread: Operation for this "
+                                              "entry is %s" % str(operation))
 
-                                # Remove
-                                if operation == 'd':
-                                    docman.remove(
-                                        entry['o']['_id'], ns, timestamp)
-                                    remove_inc += 1
+                                    # Remove
+                                    if operation == 'd':
+                                        docman.remove(
+                                            entry['o']['_id'], ns, timestamp)
+                                        remove_inc += 1
 
-                                # Insert
-                                elif operation == 'i':  # Insert
-                                    # Retrieve inserted document from
-                                    # 'o' field in oplog record
-                                    doc = entry.get('o')
-                                    # Extract timestamp and namespace
-                                    if is_gridfs_file:
-                                        db, coll = ns.split('.', 1)
-                                        gridfile = GridFSFile(
-                                            self.primary_client[db][coll],
-                                            doc)
-                                        docman.insert_file(
-                                            gridfile, ns, timestamp)
-                                    else:
-                                        docman.upsert(doc, ns, timestamp)
-                                    upsert_inc += 1
+                                    # Insert
+                                    elif operation == 'i':  # Insert
+                                        # Retrieve inserted document from
+                                        # 'o' field in oplog record
+                                        doc = entry.get('o')
+                                        # Extract timestamp and namespace
+                                        if is_gridfs_file:
+                                            db, coll = ns.split('.', 1)
+                                            gridfile = GridFSFile(
+                                                self.primary_client[db][coll],
+                                                doc)
+                                            docman.insert_file(
+                                                gridfile, ns, timestamp)
+                                        else:
+                                            docman.upsert(doc, ns, timestamp)
+                                        upsert_inc += 1
 
-                                # Update
-                                elif operation == 'u':
-                                    docman.update(entry['o2']['_id'],
-                                                  entry['o'],
-                                                  ns, timestamp)
-                                    update_inc += 1
+                                    # Update
+                                    elif operation == 'u':
+                                        docman.update(entry['o2']['_id'],
+                                                      entry['o'],
+                                                      ns, timestamp)
+                                        update_inc += 1
 
-                                # Command
-                                elif operation == 'c':
-                                    # use unmapped namespace
-                                    doc = entry.get('o')
-                                    docman.handle_command(doc,
-                                                          entry['ns'],
-                                                          timestamp)
+                                    # Command
+                                    elif operation == 'c':
+                                        # use unmapped namespace
+                                        doc = entry.get('o')
+                                        docman.handle_command(doc,
+                                                              entry['ns'],
+                                                              timestamp)
 
-                            except errors.OperationFailed:
-                                LOG.exception(
-                                    "Unable to process oplog document %r"
-                                    % entry)
-                            except errors.ConnectionFailed:
-                                LOG.exception(
-                                    "Connection failed while processing oplog "
-                                    "document %r" % entry)
+                        except errors.OperationFailed:
+                            LOG.exception(
+                                "Unable to process oplog document %r"
+                                % entry)
+                            cursor.close()
+                            break
+                        except errors.ConnectionFailed:
+                            LOG.exception(
+                                "Connection failed while processing oplog "
+                                "document %r" % entry)
+                            cursor.close()
+                            break
 
                         if (remove_inc + upsert_inc + update_inc) % 1000 == 0:
                             LOG.debug(

--- a/tests/test_synchronizer.py
+++ b/tests/test_synchronizer.py
@@ -18,9 +18,12 @@
 import os
 import sys
 import time
+import types
+import bson
 
 sys.path[0:0] = [""]
 
+from mongo_connector import errors
 from mongo_connector.connector import Connector
 from mongo_connector.test_utils import ReplicaSet, connector_opts, assert_soon
 from tests import unittest
@@ -147,6 +150,37 @@ class TestSynchronizer(unittest.TestCase):
             # cleanup
             opthread.fields = None
 
+    def test_operation_failure_recovery(self):
+        """Test that synchronizer operation failure does not lose documents."""
+        def check_ids(ids):
+            self.assertEqual(ids, set(doc["_id"] for doc in self.synchronizer._search()))
+
+        id1 = bson.ObjectId("111111111111111111111111")
+        id2 = bson.ObjectId("222222222222222222222222")
+        id3 = bson.ObjectId("333333333333333333333333")
+
+        self.conn.test.test.insert_one({"_id": id1, "x": 1})
+
+        time.sleep(1)
+        check_ids(set([id1]))
+
+        # Monkey patch docmanager to fail to upsert
+        orig_upsert = self.synchronizer.upsert
+
+        def fail_upsert(self, doc, namespace, timestamp):
+            self.upsert = orig_upsert
+            raise errors.OperationFailed("synthetic failure")
+
+        self.synchronizer.upsert = types.MethodType(fail_upsert, self.synchronizer)
+        self.conn.test.test.insert_one({"_id": id2, "x": 2})
+        while self.synchronizer.upsert != orig_upsert:
+            time.sleep(1)
+
+        # Insert another document, ensure the previous failed document is now upserted
+        check_ids(set([id1]))
+        self.conn.test.test.insert_one({"_id": id3, "x": 3})
+        time.sleep(3)
+        check_ids(set([id1, id2, id3]))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_synchronizer.py
+++ b/tests/test_synchronizer.py
@@ -169,7 +169,7 @@ class TestSynchronizer(unittest.TestCase):
 
         def fail_upsert(self, doc, namespace, timestamp):
             self.upsert = orig_upsert
-            raise errors.OperationFailed("synthetic failure")
+            raise errors.TransientOperationFailed("synthetic failure")
 
         self.synchronizer.upsert = types.MethodType(fail_upsert, self.synchronizer)
         self.conn.test.test.insert_one({"_id": id2, "x": 2})


### PR DESCRIPTION
Currently if any docman raises `OperationFailure` while processing an operation, mongo-connector just continues processing further oplog entries and updates the oplog.timestamp.

This means back end systems lose all updates that occurred during any temporary outage. We use a PostgreSQL docmanager and it is full of missing and out of date documents due to restarting postgres. mongo-connector handled the failure by just continying with the next oplog entry, and the failed entry will never be replicated.

This change breaks out of the mongo oplog cursor iteration loop if any docman fails, the cursor is then re-established and the failing oplog entry is reprocessed. The change to oplog_manager.py is almost all whitespace (indentation).