### PR TITLE
Log a warning regarding missing pymongo C extensions.

### DIFF
--- a/mongo_connector/connector.py
+++ b/mongo_connector/connector.py
@@ -65,6 +65,10 @@ class Connector(threading.Thread):
             LOG.warning('No doc managers specified, using simulator.')
             self.doc_managers = (simulator.DocManager(),)
 
+        # Warning when pymongo does not have C extensions regarding possible "Date out of range" errors
+        if not pymongo.has_c():
+            LOG.warning('pymongo was installed without C extensions. Possible "Date out of range" errors may occur.')
+
         # Password for authentication
         self.auth_key = kwargs.pop('auth_key', None)
 


### PR DESCRIPTION
For those that are new to Python or are not familiar with PyMongo, `InvalidBSON` errors regarding dates can be confusing (I was one of those people). If the `pymongo` package was installed without C extensions, there will now be a warning log entry notifying users of possible "Date out of range" errors.

This is a replacement for the unnecessary #487 which will be closed.