### PR TITLE
Reduce test suite run time

### DIFF
--- a/mongo_connector/test_utils.py
+++ b/mongo_connector/test_utils.py
@@ -171,15 +171,7 @@ class ReplicaSet(MCTestObject):
         return self._init_from_response(self._make_post_request())
 
 
-class ReplicaSetSingle(MCTestObject):
-
-    _resource = 'replica_sets'
-
-    def __init__(self, id=None, uri=None, primary=None, **kwargs):
-        self.id = id
-        self.uri = uri
-        self.primary = primary
-        self._proc_params = kwargs
+class ReplicaSetSingle(ReplicaSet):
 
     def get_config(self):
         return {
@@ -187,17 +179,6 @@ class ReplicaSetSingle(MCTestObject):
                 {'procParams': self.proc_params()}
             ]
         }
-
-    def _init_from_response(self, response):
-        self.id = response['id']
-        self.uri = response.get('mongodb_auth_uri', response['mongodb_uri'])
-        member = response['members'][0]
-        self.primary = Server(member['server_id'], member['host'])
-        return self
-
-    def start(self):
-        # We never need to restart a replica set, only start new ones.
-        return self._init_from_response(self._make_post_request())
 
 
 class ShardedCluster(MCTestObject):

--- a/tests/test_command_replication.py
+++ b/tests/test_command_replication.py
@@ -155,6 +155,5 @@ class TestCommandReplication(unittest.TestCase):
             'test.test2')
 
 
-
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_command_replication.py
+++ b/tests/test_command_replication.py
@@ -26,7 +26,9 @@ from mongo_connector.command_helper import CommandHelper
 from mongo_connector.doc_managers.doc_manager_base import DocManagerBase
 from mongo_connector.locking_dict import LockingDict
 from mongo_connector.oplog_manager import OplogThread
-from mongo_connector.test_utils import ReplicaSet, assert_soon, close_client
+from mongo_connector.test_utils import (assert_soon,
+                                        close_client,
+                                        ReplicaSetSingle)
 from tests import unittest
 
 
@@ -52,7 +54,7 @@ class CommandLoggerDocManager(DocManagerBase):
 
 class TestCommandReplication(unittest.TestCase):
     def setUp(self):
-        self.repl_set = ReplicaSet().start()
+        self.repl_set = ReplicaSetSingle().start()
         self.primary_conn = self.repl_set.client()
         self.oplog_progress = LockingDict()
         self.opman = None

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -23,7 +23,7 @@ sys.path[0:0] = [""]
 from mongo_connector import config, errors, connector
 from mongo_connector.connector import get_config_options, setup_logging
 from mongo_connector.doc_managers import doc_manager_simulator
-from mongo_connector.test_utils import ReplicaSet
+
 from tests import unittest
 
 from_here = lambda *paths: os.path.join(
@@ -74,7 +74,8 @@ class TestConfig(unittest.TestCase):
             'logging': {
                 'type': u'file',
                 'filename': u'testFilename',
-                'format': u'%(asctime)s [%(levelname)s] %(name)s:%(lineno)d - %(message)s',
+                'format': u'%(asctime)s [%(levelname)s] %(name)s:%(lineno)d'
+                          u' - %(message)s',
                 'rotationWhen': u'midnight',
                 'rotationInterval': 1,
                 'rotationBackups': 7,
@@ -116,7 +117,8 @@ class TestConfig(unittest.TestCase):
         self.assertEqual(self.conf['logging'], {
             'type': u'syslog',
             'filename': u'testFilename',
-            'format': u'%(asctime)s [%(levelname)s] %(name)s:%(lineno)d - %(message)s',
+            'format': u'%(asctime)s [%(levelname)s] %(name)s:%(lineno)d'
+                      u' - %(message)s',
             'rotationWhen': u'midnight',
             'rotationInterval': 1,
             'rotationBackups': 7,
@@ -480,7 +482,8 @@ class TestConnectorConfig(unittest.TestCase):
 
         # Test keyword arguments passed to OplogThread.
         ot_kwargs = mc.kwargs
-        self.assertEqual(ot_kwargs['ns_set'], self.config['namespaces.include'])
+        self.assertEqual(ot_kwargs['ns_set'],
+                         self.config['namespaces.include'])
         self.assertEqual(ot_kwargs['collection_dump'],
                          not self.config['noDump'])
         self.assertEqual(ot_kwargs['gridfs_set'],
@@ -491,7 +494,8 @@ class TestConnectorConfig(unittest.TestCase):
         self.assertEqual(ot_kwargs['batch_size'], self.config['batchSize'])
 
         # Test DocManager options.
-        for dm, dm_expected in zip(mc.doc_managers, self.config['docManagers']):
+        for dm, dm_expected in zip(mc.doc_managers,
+                                   self.config['docManagers']):
             self.assertEqual(dm.kwargs, dm_expected.kwargs)
             self.assertEqual(dm.auto_commit_interval,
                              dm_expected.auto_commit_interval)

--- a/tests/test_connector_sharded.py
+++ b/tests/test_connector_sharded.py
@@ -54,3 +54,7 @@ class TestConnectorSharded(unittest.TestCase):
         assert_soon(lambda: len(dm._search()) > 0)
 
         connector.join()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_connector_sharded.py
+++ b/tests/test_connector_sharded.py
@@ -13,13 +13,16 @@
 # limitations under the License.
 
 import os
+import sys
+
+sys.path[0:0] = [""]
 
 from mongo_connector.connector import Connector
 from mongo_connector.doc_managers.doc_manager_simulator import DocManager
-from mongo_connector.test_utils import (ShardedCluster,
+from mongo_connector.test_utils import (assert_soon,
                                         db_user,
                                         db_password,
-                                        assert_soon)
+                                        ShardedClusterSingle)
 from tests import unittest, SkipTest
 
 
@@ -28,7 +31,7 @@ class TestConnectorSharded(unittest.TestCase):
     def setUp(self):
         if not (db_user and db_password):
             raise SkipTest('Need to set a user/password to test this.')
-        self.cluster = ShardedCluster().start()
+        self.cluster = ShardedClusterSingle().start()
 
     def tearDown(self):
         try:

--- a/tests/test_filter_fields.py
+++ b/tests/test_filter_fields.py
@@ -22,8 +22,9 @@ from mongo_connector import errors
 from mongo_connector.doc_managers.doc_manager_simulator import DocManager
 from mongo_connector.locking_dict import LockingDict
 from mongo_connector.oplog_manager import OplogThread
-from mongo_connector.test_utils import ReplicaSetSingle, assert_soon, \
-    close_client
+from mongo_connector.test_utils import (assert_soon,
+                                        close_client,
+                                        ReplicaSetSingle)
 from tests import unittest
 
 

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -121,7 +121,8 @@ class TestFormatters(unittest.TestCase):
                             for i, v in enumerate(self.lst))
         constructed1.update(constructed2)
         constructed1.update(constructed3)
-        self.assertEqual(formatter.format_document(self.doc_list), constructed1)
+        self.assertEqual(formatter.format_document(self.doc_list),
+                         constructed1)
 
 
 if __name__ == '__main__':

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -122,3 +122,7 @@ class TestFormatters(unittest.TestCase):
         constructed1.update(constructed2)
         constructed1.update(constructed3)
         self.assertEqual(formatter.format_document(self.doc_list), constructed1)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_gridfs_file.py
+++ b/tests/test_gridfs_file.py
@@ -20,7 +20,7 @@ sys.path[0:0] = [""]
 
 from mongo_connector import errors
 from mongo_connector.gridfs_file import GridFSFile
-from mongo_connector.test_utils import ReplicaSet, close_client
+from mongo_connector.test_utils import ReplicaSetSingle, close_client
 from tests import unittest
 
 
@@ -29,7 +29,7 @@ class TestGridFSFile(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         # Start up a replica set and connect to it
-        cls.repl_set = ReplicaSet().start()
+        cls.repl_set = ReplicaSetSingle().start()
         cls.main_connection = cls.repl_set.client()
 
     @classmethod

--- a/tests/test_mongo.py
+++ b/tests/test_mongo.py
@@ -61,7 +61,8 @@ class MongoTestCase(unittest.TestCase):
         collection_name = 'test.test'
         if self.use_single_meta_collection:
             collection_name = '__oplog'
-        for doc in self.mongo_conn['__mongo_connector'][collection_name].find():
+        col = self.mongo_conn['__mongo_connector'][collection_name]
+        for doc in col.find():
             if doc.get('gridfs_id'):
                 for f in fs.find({'_id': doc['gridfs_id']}):
                     doc['filename'] = f.filename

--- a/tests/test_mongo.py
+++ b/tests/test_mongo.py
@@ -108,9 +108,7 @@ class TestMongo(MongoTestCase):
             **connector_opts
         )
 
-        self.conn.test.test.drop()
-        self.conn.test.test.files.drop()
-        self.conn.test.test.chunks.drop()
+        self.conn.drop_database('test')
 
         self.connector.start()
         assert_soon(lambda: len(self.connector.shard_set) > 0)

--- a/tests/test_mongo_connector.py
+++ b/tests/test_mongo_connector.py
@@ -25,7 +25,7 @@ from bson.timestamp import Timestamp
 sys.path[0:0] = [""]
 
 from mongo_connector.connector import Connector
-from mongo_connector.test_utils import ReplicaSet, connector_opts
+from mongo_connector.test_utils import ReplicaSetSingle, connector_opts
 from mongo_connector.util import long_to_bson_ts
 from tests import unittest
 
@@ -43,7 +43,7 @@ class TestMongoConnector(unittest.TestCase):
         except OSError:
             pass
         open("oplog.timestamp", "w").close()
-        cls.repl_set = ReplicaSet().start()
+        cls.repl_set = ReplicaSetSingle().start()
 
     @classmethod
     def tearDownClass(cls):
@@ -85,21 +85,21 @@ class TestMongoConnector(unittest.TestCase):
             **connector_opts
         )
 
-        #test that None is returned if there is no config file specified.
+        # test that None is returned if there is no config file specified.
         self.assertEqual(conn.write_oplog_progress(), None)
 
         conn.oplog_progress.get_dict()[1] = Timestamp(12, 34)
-        #pretend to insert a thread/timestamp pair
+        # pretend to insert a thread/timestamp pair
         conn.write_oplog_progress()
 
         data = json.load(open("temp_oplog.timestamp", 'r'))
         self.assertEqual(1, int(data[0]))
         self.assertEqual(long_to_bson_ts(int(data[1])), Timestamp(12, 34))
 
-        #ensure the temp file was deleted
+        # ensure the temp file was deleted
         self.assertFalse(os.path.exists("temp_oplog.timestamp" + '~'))
 
-        #ensure that updates work properly
+        # ensure that updates work properly
         conn.oplog_progress.get_dict()[1] = Timestamp(44, 22)
         conn.write_oplog_progress()
 
@@ -122,7 +122,7 @@ class TestMongoConnector(unittest.TestCase):
             **connector_opts
         )
 
-        #testing with no file
+        # testing with no file
         self.assertEqual(conn.read_oplog_progress(), None)
 
         try:
@@ -133,12 +133,12 @@ class TestMongoConnector(unittest.TestCase):
 
         conn.oplog_checkpoint = "temp_oplog.timestamp"
 
-        #testing with empty file
+        # testing with empty file
         self.assertEqual(conn.read_oplog_progress(), None)
 
         oplog_dict = conn.oplog_progress.get_dict()
 
-        #add a value to the file, delete the dict, and then read in the value
+        # add a value to the file, delete the dict, and then read in the value
         oplog_dict['oplog1'] = Timestamp(12, 34)
         conn.write_oplog_progress()
         del oplog_dict['oplog1']
@@ -153,7 +153,7 @@ class TestMongoConnector(unittest.TestCase):
 
         oplog_dict['oplog1'] = Timestamp(55, 11)
 
-        #see if oplog progress dict is properly updated
+        # see if oplog progress dict is properly updated
         conn.read_oplog_progress()
         self.assertTrue(oplog_dict['oplog1'], Timestamp(55, 11))
 

--- a/tests/test_mongo_doc_manager.py
+++ b/tests/test_mongo_doc_manager.py
@@ -268,9 +268,11 @@ class TestMongoDocManager(MongoTestCase):
             self.assertNotIn('test2',
                              self.mongo_conn['test'].collection_names())
 
-            # WiredTiger drops the database when the last collection is dropped.
+            # WiredTiger drops the database when the last collection is
+            # dropped.
             if 'test' not in self.mongo_conn.database_names():
-                self.choosy_docman.handle_command({'create': 'test'}, *TESTARGS)
+                self.choosy_docman.handle_command({'create': 'test'},
+                                                  *TESTARGS)
             self.assertIn('test', self.mongo_conn.database_names())
             self.choosy_docman.handle_command(
                 {'dropDatabase': 1}, 'test.$cmd', 1)

--- a/tests/test_oplog_manager.py
+++ b/tests/test_oplog_manager.py
@@ -28,7 +28,9 @@ sys.path[0:0] = [""]
 from mongo_connector.doc_managers.doc_manager_simulator import DocManager
 from mongo_connector.locking_dict import LockingDict
 from mongo_connector.oplog_manager import OplogThread
-from mongo_connector.test_utils import ReplicaSet, assert_soon, close_client
+from mongo_connector.test_utils import (assert_soon,
+                                        close_client,
+                                        ReplicaSetSingle)
 from mongo_connector.util import bson_ts_to_long
 from tests import unittest
 
@@ -39,7 +41,7 @@ class TestOplogManager(unittest.TestCase):
     """
 
     def setUp(self):
-        self.repl_set = ReplicaSet().start()
+        self.repl_set = ReplicaSetSingle().start()
         self.primary_conn = self.repl_set.client()
         self.oplog_coll = self.primary_conn.local['oplog.rs']
         self.opman = OplogThread(
@@ -139,7 +141,7 @@ class TestOplogManager(unittest.TestCase):
 
         # Case 3
         # 1MB oplog so that we can rollover quickly
-        repl_set = ReplicaSet(oplogSize=1).start()
+        repl_set = ReplicaSetSingle(oplogSize=1).start()
         conn = repl_set.client()
         opman = OplogThread(
             primary_client=conn,

--- a/tests/test_rollbacks.py
+++ b/tests/test_rollbacks.py
@@ -29,10 +29,10 @@ sys.path[0:0] = [""]
 from mongo_connector.doc_managers.doc_manager_simulator import DocManager
 from mongo_connector.locking_dict import LockingDict
 from mongo_connector.oplog_manager import OplogThread
-from mongo_connector.test_utils import (ReplicaSet,
-                                        STRESS_COUNT,
-                                        assert_soon,
-                                        close_client)
+from mongo_connector.test_utils import (assert_soon,
+                                        close_client,
+                                        ReplicaSet,
+                                        STRESS_COUNT)
 from mongo_connector.util import retry_until_ok
 from tests import unittest
 
@@ -42,6 +42,11 @@ class TestRollbacks(unittest.TestCase):
     def tearDown(self):
         close_client(self.primary_conn)
         close_client(self.secondary_conn)
+        try:
+            self.opman.join()
+        except RuntimeError:
+            # OplogThread may not have been started
+            pass
         self.repl_set.stop()
 
     def setUp(self):
@@ -63,7 +68,7 @@ class TestRollbacks(unittest.TestCase):
             read_preference=ReadPreference.SECONDARY_PREFERRED)
 
         # Wipe any test data
-        self.main_conn["test"]["mc"].drop()
+        self.main_conn.drop_database("test")
 
         # Oplog thread
         doc_manager = DocManager()
@@ -305,3 +310,7 @@ class TestRollbacks(unittest.TestCase):
                                 % (STRESS_COUNT, len(docman._search()))))
 
         self.opman.join()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_synchronizer.py
+++ b/tests/test_synchronizer.py
@@ -22,7 +22,9 @@ import time
 sys.path[0:0] = [""]
 
 from mongo_connector.connector import Connector
-from mongo_connector.test_utils import ReplicaSet, connector_opts, assert_soon
+from mongo_connector.test_utils import (assert_soon,
+                                        connector_opts,
+                                        ReplicaSetSingle)
 from tests import unittest
 
 
@@ -40,7 +42,7 @@ class TestSynchronizer(unittest.TestCase):
             pass
         open("oplog.timestamp", "w").close()
 
-        cls.repl_set = ReplicaSet().start()
+        cls.repl_set = ReplicaSetSingle().start()
         cls.conn = cls.repl_set.client()
         cls.connector = Connector(
             mongo_address=cls.repl_set.uri,


### PR DESCRIPTION
Helps with #528. Shaves off almost 20 minutes from the test suite ([22 minutes](https://travis-ci.org/mongodb-labs/mongo-connector/builds/160289698) compared to [39 minutes](https://travis-ci.org/ShaneHarvey/mongo-connector/builds/155408276)). 