### PR TITLE
Properly filter dot notation fields (including arrays) in updates

### DIFF
--- a/mongo_connector/oplog_manager.py
+++ b/mongo_connector/oplog_manager.py
@@ -431,9 +431,9 @@ class OplogThread(threading.Thread):
         try:
             for key in path:
                 doc = doc[key]
+            return [(path, doc)]
         except (KeyError, TypeError):
             return []
-        return [(path, doc)]
 
     @classmethod
     def _find_update_fields(cls, field, doc):
@@ -479,8 +479,7 @@ class OplogThread(threading.Thread):
         find_fields = self._find_update_fields if update else self._find_field
         for field in self._exclude_fields:
             for path, _ in find_fields(field, doc):
-                # If we found a matching field in the original document,
-                # delete it.
+                # Delete each matching field in the original document.
                 temp_doc = doc
                 for p in path[:-1]:
                     temp_doc = temp_doc[p]
@@ -493,8 +492,7 @@ class OplogThread(threading.Thread):
         find_fields = self._find_update_fields if update else self._find_field
         for field in self._fields:
             for path, value in find_fields(field, doc):
-                # If we found a matching field in the original document,
-                # copy it.
+                # Copy each matching field in the original document.
                 temp_doc = new_doc
                 for p in path[:-1]:
                     temp_doc = temp_doc.setdefault(p, {})

--- a/mongo_connector/oplog_manager.py
+++ b/mongo_connector/oplog_manager.py
@@ -443,7 +443,7 @@ class OplogThread(threading.Thread):
         notation, eg "a.b.c". Returns a list of tuples (path, field_value) or
         the empty list if the field is not present.
         """
-        def find_all_fields():
+        def find_partial_matches():
             for key in doc:
                 if len(key) > len(field):
                     # Handle case where field is a prefix of key, eg field is
@@ -467,9 +467,12 @@ class OplogThread(threading.Thread):
                         # Stop searching, it's not possible for any other
                         # keys in the update doc to match this field.
                         return
-        if field in doc:
+
+        try:
             return [([field], doc[field])]
-        return list(find_all_fields())
+        except KeyError:
+            # Field does not exactly match any key in the update doc.
+            return list(find_partial_matches())
 
     def _pop_excluded_fields(self, doc, update=False):
         # Remove all the fields that were passed in exclude_fields.

--- a/mongo_connector/oplog_manager.py
+++ b/mongo_connector/oplog_manager.py
@@ -419,59 +419,74 @@ class OplogThread(threading.Thread):
         self.running = False
         threading.Thread.join(self)
 
+    @classmethod
+    def find_field(cls, field, doc):
+        """Find the field in the document which matches the given field.
+
+        The field may be in dot notation, eg "a.b.c". Yields a tuple
+        (path, field_value).
+        """
+        path = field.split('.')
+        try:
+            for key in path:
+                doc = doc[key]
+        except (KeyError, TypeError):
+            return
+        yield path, doc
+
+    @classmethod
+    def find_update_fields(cls, field, doc):
+        """Find the fields in the update document which match the given field.
+
+        Both the field and the top level keys in the doc may be in dot
+        notation, eg "a.b.c". Yields tuples (path, field_value).
+        """
+        if field in doc:
+            yield [field], doc[field]
+            return
+        for key in doc:
+            if len(key) > len(field):
+                # Handle case where field is 'a' and key is 'a.b'
+                if key.startswith(field) and key[len(field)] == '.':
+                    yield [key], doc[key]
+                    # Continue searching, there may be multiple matches.
+                    # For example, 'a' will match 'a.b' and 'a.c'.
+            elif len(key) < len(field):
+                # Handle case where field is 'a.b' and key is 'a'
+                if field.startswith(key) and field[len(key)] == '.':
+                    remaining = field[len(key) + 1:]
+                    match = list(cls.find_field(remaining, doc[key]))
+                    if match:
+                        path, value = match[0]
+                        path.insert(0, key)
+                        yield path, value
+                        return
+
     def _pop_excluded_fields(self, doc, update=False):
         # Remove all the fields that were passed in exclude_fields.
+        find_fields = self.find_update_fields if update else self.find_field
         for field in self._exclude_fields:
-            curr_doc = doc
-            dots = field.split('.')
-            remove_up_to = curr_doc
-            end = dots[0]
-            for part in dots:
-                if not isinstance(curr_doc, dict) or part not in curr_doc:
-                    break
-                elif len(curr_doc) != 1:
-                    remove_up_to = curr_doc
-                    end = part
-                curr_doc = curr_doc[part]
-            else:
-                remove_up_to.pop(end)
+            for path, _ in list(find_fields(field, doc)):
+                # If we found a matching field in the original document,
+                # delete it.
+                temp_doc = doc
+                for p in path[:-1]:
+                    temp_doc = temp_doc[p]
+                temp_doc.pop(path[-1])
+
         return doc  # Need this to be similar to copy_included_fields.
-
-    def _contains_field(self, selector, doc, pos=0, path=[]):
-        # check if a given document contains allowed properties and return
-        # value and path for it
-        # parameter selector is a list of property names
-        # pos is internally used to know where in the selector we are
-        # path is used to be able to return a path for the new_doc for updating
-
-        if pos < len(selector):
-            for selpos in range(len(selector) - pos):
-                sel = ".".join(selector[pos:pos+selpos+1])
-                if sel in doc:
-                    return self._contains_field(selector, doc[sel],
-                                    pos=pos+selpos+1,
-                                    path=path + selector[pos:pos+selpos+1])
-            return False, None, path
-        else:
-            return True, doc, path
 
     def _copy_included_fields(self, doc, update=False):
         new_doc = {}
-        for field in self.fields:
-            selector = field.split(".")
-            found, value, path = self._contains_field(selector, doc)
-            if found:
-                if update:
-                    # create a diff object (with dot convention)
-                    new_doc[".".join(path)] = value
-                else:
-                    # create a full document
-                    d = new_doc
-                    for p in path[:-1]:
-                        if not p in d:
-                            d[p] = {}
-                        d = d[p]
-                    d[path[-1]] = value
+        find_fields = self.find_update_fields if update else self.find_field
+        for field in self._fields:
+            for path, value in list(find_fields(field, doc)):
+                # If we found a matching field in the original document,
+                # copy it.
+                temp_doc = new_doc
+                for p in path[:-1]:
+                    temp_doc = temp_doc.setdefault(p, {})
+                temp_doc[path[-1]] = value
 
         return new_doc
 
@@ -494,9 +509,11 @@ class OplogThread(threading.Thread):
         # if '$set' or '$unset' are present.
         elif entry['op'] == 'u' and ('$set' in entry_o or '$unset' in entry_o):
             if '$set' in entry_o:
-                entry['o']["$set"] = filter_fields(entry_o["$set"], update=True)
+                entry['o']["$set"] = filter_fields(entry_o["$set"],
+                                                   update=True)
             if '$unset' in entry_o:
-                entry['o']["$unset"] = filter_fields(entry_o["$unset"], update=True)
+                entry['o']["$unset"] = filter_fields(entry_o["$unset"],
+                                                     update=True)
             # not allowed to have empty $set/$unset, so remove if empty
             if "$set" in entry_o and not entry_o['$set']:
                 entry_o.pop("$set")

--- a/mongo_connector/oplog_manager.py
+++ b/mongo_connector/oplog_manager.py
@@ -419,7 +419,7 @@ class OplogThread(threading.Thread):
         self.running = False
         threading.Thread.join(self)
 
-    def _pop_excluded_fields(self, doc):
+    def _pop_excluded_fields(self, doc, update=False):
         # Remove all the fields that were passed in exclude_fields.
         for field in self._exclude_fields:
             curr_doc = doc
@@ -437,23 +437,41 @@ class OplogThread(threading.Thread):
                 remove_up_to.pop(end)
         return doc  # Need this to be similar to copy_included_fields.
 
-    def _copy_included_fields(self, doc):
-        # Copy over included fields to new doc
+    def _contains_field(self, selector, doc, pos=0, path=[]):
+        # check if a given document contains allowed properties and return
+        # value and path for it
+        # parameter selector is a list of property names
+        # pos is internally used to know where in the selector we are
+        # path is used to be able to return a path for the new_doc for updating
+
+        if pos < len(selector):
+            for selpos in range(len(selector) - pos):
+                sel = ".".join(selector[pos:pos+selpos+1])
+                if sel in doc:
+                    return self._contains_field(selector, doc[sel],
+                                    pos=pos+selpos+1,
+                                    path=path + selector[pos:pos+selpos+1])
+            return False, None, path
+        else:
+            return True, doc, path
+
+    def _copy_included_fields(self, doc, update=False):
         new_doc = {}
         for field in self.fields:
-            dots = field.split('.')
-            curr_doc = doc
-            for part in dots:
-                if part not in curr_doc:
-                    break
+            selector = field.split(".")
+            found, value, path = self._contains_field(selector, doc)
+            if found:
+                if update:
+                    # create a diff object (with dot convention)
+                    new_doc[".".join(path)] = value
                 else:
-                    curr_doc = curr_doc[part]
-            else:
-                # If we found the field in the original document, copy it
-                edit_doc = new_doc
-                for part in dots[:-1]:
-                    edit_doc = edit_doc.setdefault(part, {})
-                edit_doc[dots[-1]] = curr_doc
+                    # create a full document
+                    d = new_doc
+                    for p in path[:-1]:
+                        if not p in d:
+                            d[p] = {}
+                        d = d[p]
+                    d[path[-1]] = value
 
         return new_doc
 
@@ -476,9 +494,9 @@ class OplogThread(threading.Thread):
         # if '$set' or '$unset' are present.
         elif entry['op'] == 'u' and ('$set' in entry_o or '$unset' in entry_o):
             if '$set' in entry_o:
-                entry['o']["$set"] = filter_fields(entry_o["$set"])
+                entry['o']["$set"] = filter_fields(entry_o["$set"], update=True)
             if '$unset' in entry_o:
-                entry['o']["$unset"] = filter_fields(entry_o["$unset"])
+                entry['o']["$unset"] = filter_fields(entry_o["$unset"], update=True)
             # not allowed to have empty $set/$unset, so remove if empty
             if "$set" in entry_o and not entry_o['$set']:
                 entry_o.pop("$set")

--- a/tests/test_filter_fields.py
+++ b/tests/test_filter_fields.py
@@ -708,6 +708,11 @@ class TestFilterFields(unittest.TestCase):
         filtered_update = {'$set': {'b': 3}}
         check_nested(update, exclude_fields, filtered_update, op='u')
 
+        update = {'$set': {'a.b.c': 42, 'd.e.f': 123, 'g': 456}}
+        exclude_fields = ['a.b', 'd']
+        filtered_update = {'$set': {'g': 456}}
+        check_nested(update, exclude_fields, filtered_update, op='u')
+
         update = {'$set': {'a.b': {'c': 3, 'd': 1}, 'a.e': 1}}
         exclude_fields = ['a.b', 'a.e']
         filtered_update = None

--- a/tests/test_filter_fields.py
+++ b/tests/test_filter_fields.py
@@ -768,50 +768,50 @@ class TestFilterFields(unittest.TestCase):
 class TestFindFields(unittest.TestCase):
     def test_find_field(self):
         doc = {'a': {'b': {'c': 1}}}
-        self.assertEqual(list(OplogThread.find_field('a', doc)),
+        self.assertEqual(OplogThread._find_field('a', doc),
                          [(['a'], doc['a'])])
-        self.assertEqual(list(OplogThread.find_field('a.b', doc)),
+        self.assertEqual(OplogThread._find_field('a.b', doc),
                          [(['a', 'b'], doc['a']['b'])])
-        self.assertEqual(list(OplogThread.find_field('a.b.c', doc)),
+        self.assertEqual(OplogThread._find_field('a.b.c', doc),
                          [(['a', 'b', 'c'], doc['a']['b']['c'])])
-        self.assertEqual(list(OplogThread.find_field('x', doc)),
+        self.assertEqual(OplogThread._find_field('x', doc),
                          [])
-        self.assertEqual(list(OplogThread.find_field('a.b.x', doc)),
+        self.assertEqual(OplogThread._find_field('a.b.x', doc),
                          [])
 
     def test_find_update_fields(self):
         doc = {'a': {'b': {'c': 1}}, 'e.f': 1, 'g.h': {'i': {'j': 1}}}
-        self.assertEqual(list(OplogThread.find_update_fields('a', doc)),
+        self.assertEqual(OplogThread._find_update_fields('a', doc),
                          [(['a'], doc['a'])])
-        self.assertEqual(list(OplogThread.find_update_fields('a.b', doc)),
+        self.assertEqual(OplogThread._find_update_fields('a.b', doc),
                          [(['a', 'b'], doc['a']['b'])])
-        self.assertEqual(list(OplogThread.find_update_fields('a.b.c', doc)),
+        self.assertEqual(OplogThread._find_update_fields('a.b.c', doc),
                          [(['a', 'b', 'c'], doc['a']['b']['c'])])
-        self.assertEqual(list(OplogThread.find_update_fields('x', doc)),
+        self.assertEqual(OplogThread._find_update_fields('x', doc),
                          [])
-        self.assertEqual(list(OplogThread.find_update_fields('a.b.x', doc)),
+        self.assertEqual(OplogThread._find_update_fields('a.b.x', doc),
                          [])
-        self.assertEqual(list(OplogThread.find_update_fields('e.f', doc)),
+        self.assertEqual(OplogThread._find_update_fields('e.f', doc),
                          [(['e.f'], doc['e.f'])])
-        self.assertEqual(list(OplogThread.find_update_fields('e', doc)),
+        self.assertEqual(OplogThread._find_update_fields('e', doc),
                          [(['e.f'], doc['e.f'])])
-        self.assertEqual(list(OplogThread.find_update_fields('g.h.i.j', doc)),
+        self.assertEqual(OplogThread._find_update_fields('g.h.i.j', doc),
                          [(['g.h', 'i', 'j'], doc['g.h']['i']['j'])])
 
         # Test multiple matches
         doc = {'a.b': 1, 'a.c': 2, 'e.f.h': 3, 'e.f.i': 4}
-        matches = list(OplogThread.find_update_fields('a', doc))
+        matches = OplogThread._find_update_fields('a', doc)
         self.assertEqual(len(matches), 2)
         self.assertIn((['a.b'], doc['a.b']), matches)
         self.assertIn((['a.c'], doc['a.c']), matches)
-        matches = list(OplogThread.find_update_fields('e.f', doc))
+        matches = OplogThread._find_update_fields('e.f', doc)
         self.assertEqual(len(matches), 2)
         self.assertIn((['e.f.h'], doc['e.f.h']), matches)
         self.assertIn((['e.f.i'], doc['e.f.i']), matches)
 
         # Test updates to array fields
         doc = {'a.b.1': 9, 'a.b.3': 10, 'a.b.4.c': 11}
-        matches = list(OplogThread.find_update_fields('a.b', doc))
+        matches = OplogThread._find_update_fields('a.b', doc)
         self.assertEqual(len(matches), 3)
         self.assertIn((['a.b.1'], doc['a.b.1']), matches)
         self.assertIn((['a.b.3'], doc['a.b.3']), matches)


### PR DESCRIPTION
Properly filter dot notation fields (including arrays) in updates. Fields and exclude fields still do not support *spanning* arrays but referencing array fields themselves is now supported.
Includes tests for filtering updates with dot notation fields and arrays.

Fixes #477 (Update of nested properties filtered out).
Resolves #520 (Feature Request: `fields` option should propagate edits to array elements). Updates such as `{ $set: { "array.0": "newValue" } }` and `{ $set: { "nested.array.0": "newValue" } }` are now included or excluded correctly.

This pull request builds on Robert Aistleitner's fix for the same issue submitted here #478. Thanks @robertaistleitner!