### PR TITLE
Remove tailable cursor option when checking if a cursor is empty

### DIFF
--- a/mongo_connector/oplog_manager.py
+++ b/mongo_connector/oplog_manager.py
@@ -784,7 +784,9 @@ class OplogThread(threading.Thread):
 
     def _cursor_empty(self, cursor):
         try:
-            next(cursor.clone().limit(-1))
+            # Tailable cursors can not have singleBatch=True in MongoDB > 3.3
+            next(cursor.clone().remove_option(CursorType.TAILABLE_AWAIT)
+                 .limit(-1))
             return False
         except StopIteration:
             return True


### PR DESCRIPTION
PyMongo sends a -1 limit as a query with `singleBatch=True, batchSize=1`. MongoDB 3.3.1 removed the ability to ask for `singleBatch` on a tailable cursor. Removing the tailable option solves the problem in all versions.