### PR TITLE
Log the current replication lag every 30 seconds

### DIFF
--- a/mongo_connector/oplog_manager.py
+++ b/mongo_connector/oplog_manager.py
@@ -41,7 +41,7 @@ LOG = logging.getLogger(__name__)
 class ReplicationLagLogger(threading.Thread):
     """Thread that periodically logs the current replication lag.
     """
-    def __init__(self, opman, interval=30):
+    def __init__(self, opman, interval):
         super(ReplicationLagLogger, self).__init__()
         self.opman = opman
         self.interval = interval
@@ -51,8 +51,7 @@ class ReplicationLagLogger(threading.Thread):
         checkpoint = self.opman.checkpoint
         if checkpoint is None:
             return
-        newest_write = retry_until_ok(
-            self.opman.get_last_oplog_timestamp)
+        newest_write = retry_until_ok(self.opman.get_last_oplog_timestamp)
         if newest_write < checkpoint:
             # OplogThread will perform a rollback, don't log anything
             return

--- a/mongo_connector/oplog_manager.py
+++ b/mongo_connector/oplog_manager.py
@@ -38,6 +38,46 @@ from mongo_connector.util import log_fatal_exceptions, retry_until_ok
 LOG = logging.getLogger(__name__)
 
 
+class ReplicationLagLogger(threading.Thread):
+    """Thread that periodically logs the current replication lag.
+    """
+    def __init__(self, opman, interval=30):
+        super(ReplicationLagLogger, self).__init__()
+        self.opman = opman
+        self.interval = interval
+        self.daemon = True
+
+    def log_replication_lag(self):
+        checkpoint = self.opman.checkpoint
+        if checkpoint is None:
+            return
+        newest_write = retry_until_ok(
+            self.opman.get_last_oplog_timestamp)
+        if newest_write < checkpoint:
+            # OplogThread will perform a rollback, don't log anything
+            return
+        lag_secs = newest_write.time - checkpoint.time
+        if lag_secs > 0:
+            LOG.info("OplogThread for replica set '%s' is %s seconds behind "
+                     "the oplog.",
+                     self.opman.replset_name, lag_secs)
+        else:
+            lag_inc = newest_write.inc - checkpoint.inc
+            if lag_inc > 0:
+                LOG.info("OplogThread for replica set '%s' is %s entries "
+                         "behind the oplog.",
+                         self.opman.replset_name, lag_inc)
+            else:
+                LOG.info("OplogThread for replica set '%s' is up to date "
+                         "with the oplog.",
+                         self.opman.replset_name)
+
+    def run(self):
+        while self.opman.is_alive():
+            self.log_replication_lag()
+            time.sleep(self.interval)
+
+
 class OplogThread(threading.Thread):
     """Thread that tails an oplog.
 
@@ -221,6 +261,7 @@ class OplogThread(threading.Thread):
     def run(self):
         """Start the oplog worker.
         """
+        ReplicationLagLogger(self, 30).start()
         LOG.debug("OplogThread: Run thread started")
         while self.running is True:
             LOG.debug("OplogThread: Getting cursor")
@@ -245,8 +286,7 @@ class OplogThread(threading.Thread):
             upsert_inc = 0
             update_inc = 0
             try:
-                LOG.debug("OplogThread: about to process new oplog "
-                          "entries")
+                LOG.debug("OplogThread: about to process new oplog entries")
                 while cursor.alive and self.running:
                     LOG.debug("OplogThread: Cursor is still"
                               " alive and thread is still running.")
@@ -386,7 +426,7 @@ class OplogThread(threading.Thread):
 
                     # update timestamp after running through oplog
                     if last_ts is not None:
-                        LOG.debug("OplogThread: updating checkpoint after"
+                        LOG.debug("OplogThread: updating checkpoint after "
                                   "processing new oplog entries")
                         self.checkpoint = last_ts
                         self.update_checkpoint()


### PR DESCRIPTION
Logging replication lag is very useful for determining how mongo-connector is performing.
This change adds a thread per replica set that periodically logs the current replication lag (either in seconds or number of oplog entries).

If the current thread is up to date the log message will be:
`2016-09-30 15:26:46,616 [INFO] mongo_connector.oplog_manager:69 - OplogThread for replica set 'source' is up to date with the oplog.`

If the current thread is behind the log message will be:
`2016-09-30 15:18:45,114 [INFO] mongo_connector.oplog_manager:59 - OplogThread for replica set 'source' is 81 seconds behind the oplog.`

or:
`2016-09-30 15:18:15,014 [INFO] mongo_connector.oplog_manager:65 - OplogThread for replica set 'source' is 36 entries behind the oplog.`

Possible improvements:
- Make the logging interval a configuration option.
- Clear up the logging statements.
- Add more info: include the raw timestamps?
