### PR TITLE
Cancellable (not resumable) collection dump

### DIFF
--- a/tests/test_oplog_manager.py
+++ b/tests/test_oplog_manager.py
@@ -192,6 +192,14 @@ class TestOplogManager(unittest.TestCase):
         for doc, correct_a in zip(docs, expected_a):
             self.assertEqual(doc['a'], correct_a)
 
+    def test_dump_collection_cancel(self):
+        """Test that dump_collection returns None when cancelled."""
+        self.primary_conn["test"]["test"].insert_one({"test": "1"})
+
+        # Pretend that the OplogThead was cancelled
+        self.opman.running = False
+        self.assertIsNone(self.opman.dump_collection())
+
     def test_init_cursor(self):
         """Test the init_cursor method
 


### PR DESCRIPTION
Do not set the checkpoint when the initial collection dump is cancelled.
This means that on the next restart after an interrupted collection dump
mongo-connector will re-dump each collection.

Fixes the bug in #514.

Also, adds some extra logging in `dump_collection`.