### PR TITLE
Update checkpoint even on skipped oplog entries

### DIFF
--- a/mongo_connector/oplog_manager.py
+++ b/mongo_connector/oplog_manager.py
@@ -446,7 +446,6 @@ class OplogThread(threading.Thread):
                         LOG.debug("OplogThread: updating checkpoint after "
                                   "processing new oplog entries")
                         self.update_checkpoint(last_ts)
-                        last_ts = None
 
             except (pymongo.errors.AutoReconnect,
                     pymongo.errors.OperationFailure,


### PR DESCRIPTION
Resolves the first half of #544 but does not address filtering no-op oplog entries in `get_oplog_cursor`.

Also streamlines `update_checkpoint` so that:
```
self.checkpoint = timestamp
self.update_checkpoint()
```
becomes:
```
self.update_checkpoint(timestamp)
```