### PR TITLE
Allow command line arguments to override the config file

### DIFF
--- a/mongo_connector/connector.py
+++ b/mongo_connector/connector.py
@@ -827,27 +827,20 @@ def get_config_options():
         "you can use `--gridfs-set test.fs`.")
 
     def apply_doc_managers(option, cli_values):
-        if cli_values['doc_manager'] is None:
-            if cli_values['target_url']:
-                raise errors.InvalidConfiguration(
-                    "Cannot create a Connector with a target URL"
-                    " but no doc manager.")
-        else:
-            if option.value is not None:
-                bulk_size = option.value[0].get(
-                    'bulkSize', constants.DEFAULT_MAX_BULK)
-            else:
-                bulk_size = constants.DEFAULT_MAX_BULK
-            option.value = [{
-                'docManager': cli_values['doc_manager'],
-                'targetURL': cli_values['target_url'],
-                'uniqueKey': cli_values['unique_key'],
-                'autoCommitInterval': cli_values['auto_commit_interval'],
-                'bulkSize': bulk_size
-            }]
-
         if not option.value:
-            return
+            if not cli_values['doc_manager'] and not cli_values['target_url']:
+                return
+            option.value = [{}]
+
+        # Command line options should override the first DocManager config.
+        cli_to_config = dict(doc_manager='docManager',
+                             target_url='targetURL',
+                             auto_commit_interval='autoCommitInterval',
+                             unique_key='uniqueKey')
+        first_dm = option.value[0]
+        for cli_name, value in cli_values.items():
+            if value is not None:
+                first_dm[cli_to_config[cli_name]] = value
 
         # validate doc managers and fill in default values
         for dm in option.value:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -590,6 +590,13 @@ class TestConnectorConfig(unittest.TestCase):
         self.config.load_json(
             json.dumps(TestConnectorConfig.set_everything_config))
         self.config.parse_args(self.set_everything_differently_argv)
+
+        first_dm = self.config['docManagers'][0]
+        first_dm_config = self.set_everything_config['docManagers'][0]
+        self.assertEqual(first_dm.url, 'localhost:54321')
+        self.assertEqual(first_dm.chunk_size, first_dm_config['bulkSize'])
+        self.assertEqual(first_dm.kwargs.get('clientOptions'),
+                         first_dm_config['args']['clientOptions'])
         self.assertConnectorState()
 
     def test_client_options(self):


### PR DESCRIPTION
Fixes #516.

Previously it was not possible to combine command line and config options for a `docManager`. With this change, the command line `docManager` options are merged with the ***first*** `docManager` option in the config file. Options not possible to pass on the command line are retained so you can use a config file such as:
```json
{
    "docManagers": [
        {
            "docManager": "elastic2_doc_manager",
            "autoCommitInterval": 0,
            "clientOptions": {
                "timeout": 100
            }
        }
    ]
}
```
Then launch the connector via:
`$ mongo-connector -m localhost:27017 -t elastichost:9200 --auto-commit-interval=1000`

And the effect is the same as if the config file were:
```json
{
    "docManagers": [
        {
            "docManager": "elastic2_doc_manager",
            "targetURL": "elastichost:9200",
            "autoCommitInterval": 1000,
            "clientOptions": {
                "timeout": 100
            }
        }
    ]
}
```