### PR TITLE
Add --version option to print version number and exit

### DIFF
--- a/mongo_connector/__init__.py
+++ b/mongo_connector/__init__.py
@@ -13,3 +13,5 @@
 # limitations under the License.
 from pkgutil import extend_path
 __path__ = extend_path(__path__, __name__)
+
+__version__ = '2.5.0.dev0'

--- a/mongo_connector/config.py
+++ b/mongo_connector/config.py
@@ -17,6 +17,7 @@ import optparse
 import sys
 
 from mongo_connector import compat, errors
+from mongo_connector.constants import __version__
 from mongo_connector.compat import reraise
 
 
@@ -92,7 +93,7 @@ class Config(object):
         """
 
         # parse the command line options
-        parser = optparse.OptionParser()
+        parser = optparse.OptionParser(version='%prog v' + __version__)
         for option in self.options:
             for args, kwargs in option.cli_options:
                 cli_option = parser.add_option(*args, **kwargs)

--- a/mongo_connector/config.py
+++ b/mongo_connector/config.py
@@ -16,8 +16,7 @@ import logging
 import optparse
 import sys
 
-from mongo_connector import compat, errors
-from mongo_connector.constants import __version__
+from mongo_connector import compat, errors, __version__
 from mongo_connector.compat import reraise
 
 

--- a/mongo_connector/constants.py
+++ b/mongo_connector/constants.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+__version__ = '2.5.0.dev0'
+
 # Maximum # of documents to process before recording timestamp
 # default = -1 (no maximum)
 DEFAULT_BATCH_SIZE = -1

--- a/mongo_connector/constants.py
+++ b/mongo_connector/constants.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '2.5.0.dev0'
-
 # Maximum # of documents to process before recording timestamp
 # default = -1 (no maximum)
 DEFAULT_BATCH_SIZE = -1


### PR DESCRIPTION
Adding a `--version` option to make it easier for users to report their mongo-connector versions. See https://github.com/mongodb-labs/mongo-connector/issues/551#issuecomment-253850199.

The new behavior looks like:
```
$ mongo-connector --version
mongo-connector v2.5.0.dev0
```

You can also programmatically check the version via:
```python
>>> from mongo_connector import __version__
>>> print(__version__)
2.5.0.dev0
```