### PR TITLE
Bug fixes for tests and expand test matrix 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,32 @@
+sudo: false
 language: python
 python:
   - 2.6
   - 2.7
   - 3.3
-  - 3.4
   - 3.5
 
+env:
+  global:
+    - MO_ADDRESS=127.0.0.1:20000
+  matrix:
+    - MONGODB=2.6.12
+    - MONGODB=3.0.12
+    - MONGODB=3.2.10
+    - MONGODB=3.4.0-rc1
+
+matrix:
+  fast_finish: true
+
 install:
-  - pip install pymongo==2.9
-  - pip install mongo-orchestration==0.3.1
+  - pip install "mongo-orchestration>=0.6.7,<1.0"
+  - wget http://fastdl.mongodb.org/linux/mongodb-linux-x86_64-${MONGODB}.tgz
+  - tar zxf mongodb-linux-x86_64-${MONGODB}.tgz
+  - export PATH=${PWD}/mongodb-linux-x86_64-${MONGODB}/bin/:${PATH}
+  - mongod --version
 
 before_script:
-  - mongo-orchestration start
+  - mongo-orchestration start -p 20000 -b 127.0.0.1
 
 script:
   - python setup.py test

--- a/mongo_connector/test_utils.py
+++ b/mongo_connector/test_utils.py
@@ -86,9 +86,14 @@ class MCTestObject(object):
         config = _post_request_template.copy()
         config.update(self.get_config())
         ret = requests.post(
-            _mo_url(self._resource), timeout=None, json=config).json()
+            _mo_url(self._resource), timeout=None, json=config)
+        if not ret.ok:
+            raise RuntimeError(
+                "Error sending POST to cluster: %s" % (ret.text,))
+
+        ret = ret.json()
         if type(ret) == list:  # Will return a list if an error occurred.
-            raise RuntimeError("Error sending POST to cluster: %s" % (ret))
+            raise RuntimeError("Error sending POST to cluster: %s" % (ret,))
         return ret
 
     def client(self, **kwargs):

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ except ImportError:
     from setuptools import setup
 
 extra_opts = {"test_suite": "tests",
-              "tests_require": ["mongo-orchestration>= 0.2, < 0.4",
+              "tests_require": ["mongo-orchestration>=0.6.7,<1.0",
                                 "requests>=2.5.1"]}
 
 if sys.version_info[:2] == (2, 6):

--- a/tests/test_oplog_manager.py
+++ b/tests/test_oplog_manager.py
@@ -157,10 +157,9 @@ class TestOplogManager(unittest.TestCase):
         # Insert a document into a ns_set collection
         conn["test"]["test"].insert_one({"test": 1})
         # Cause the oplog to rollover on a non-ns_set collection
-        conn["test"]["ignored"].insert_many(
-            [{"test": "1" * 1024} for _ in range(1024)])
-        self.assertIsNone(
-            conn["local"]["oplog.rs"].find_one({"ns": "test.test"}))
+        while conn["local"]["oplog.rs"].find_one({"ns": "test.test"}):
+            conn["test"]["ignored"].insert_many(
+                [{"test": "1" * 1024} for _ in range(1024)])
         last_ts = opman.get_last_oplog_timestamp()
         self.assertEqual(last_ts, opman.dump_collection())
         self.assertEqual(len(opman.doc_managers[0]._search()), 1)

--- a/tests/test_oplog_manager_sharded.py
+++ b/tests/test_oplog_manager_sharded.py
@@ -187,8 +187,9 @@ class TestOplogManagerShardedSingle(ShardedClusterTestCase):
         latest_timestamp = self.opman1.get_last_oplog_timestamp()
         cursor = self.opman1.get_oplog_cursor(latest_timestamp)
         self.assertNotEqual(cursor, None)
-        self.assertEqual(cursor.count(), 1)
-        next_entry_id = cursor[0]['o']['_id']
+        entries = list(cursor)
+        self.assertEqual(len(entries), 1)
+        next_entry_id = entries[0]['o']['_id']
         retrieved = self.mongos_conn.test.mcsharded.find_one(next_entry_id)
         self.assertEqual(retrieved, doc)
 

--- a/tests/test_oplog_manager_sharded.py
+++ b/tests/test_oplog_manager_sharded.py
@@ -347,7 +347,7 @@ class TestOplogManagerShardedSingle(ShardedClusterTestCase):
         self.assertFalse(cursor_empty)
         self.assertEqual(self.opman1.checkpoint, last_ts1)
         self.assertEqual(self.opman1.read_last_checkpoint(), last_ts1)
-        self.assertEqual(cursor[0], self.opman1.get_oplog_cursor()[0])
+        self.assertEqual(next(cursor), next(self.opman1.get_oplog_cursor()))
         cursor, cursor_empty = self.opman2.init_cursor()
         self.assertFalse(cursor_empty)
         self.assertEqual(self.opman2.checkpoint, last_ts2)


### PR DESCRIPTION
Test changes:
- Add test matrix for MongoDB versions 2.6.12, 3.0.12, 3.2.10, 3.4.0-rc0.
- Drop testing of MongoDB 2.4.
- Drop testing of Python 3.4 (still testing Python 3.3 and 3.5).
- Drops Travis sudo requirement so tests startup faster and are run in docker
containers rather than full VMs.
- Require mongo-orchestration >= 0.6.7 to be able to test Python 3.

Test bug fixes:
- Fix race conditions in test_rollback
  - Fixed a test insert that sometimes inserted 2 documents instead of 1.
  - Disable the balancer before creating the sharded collection.
- Move test_with_orphan_documents to TestOplogManagerSharded because it requires secondaries.
- Do not use array notation on cursors.
- Need to call `insert_many` multiple times to cause the oplog to rollover due to WiredTiger compression.