### PR TITLE
Bug fix: filter no-op entries from the rollback cutoff query

### DIFF
--- a/mongo_connector/oplog_manager.py
+++ b/mongo_connector/oplog_manager.py
@@ -999,7 +999,7 @@ class OplogThread(threading.Thread):
         target_ts = util.long_to_bson_ts(last_inserted_doc['_ts'])
         last_oplog_entry = util.retry_until_ok(
             self.oplog.find_one,
-            {'ts': {'$lte': target_ts}},
+            {'ts': {'$lte': target_ts}, 'op': {'$ne': 'n'}},
             sort=[('$natural', pymongo.DESCENDING)]
         )
 

--- a/mongo_connector/util.py
+++ b/mongo_connector/util.py
@@ -20,6 +20,7 @@ import sys
 import time
 
 from bson.timestamp import Timestamp
+
 from mongo_connector.compat import reraise
 
 LOG = logging.getLogger(__name__)
@@ -75,6 +76,9 @@ def retry_until_ok(func, *args, **kwargs):
     while True:
         try:
             return func(*args, **kwargs)
+        except RuntimeError:
+            # Avoid masking RuntimeErrors
+            raise
         except Exception:
             count += 1
             if count > 120:

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -17,6 +17,7 @@
 import sys
 
 from bson import timestamp
+from pymongo import errors
 
 sys.path[0:0] = [""]
 
@@ -33,8 +34,10 @@ def err_func():
     err_func.counter += 1
     if err_func.counter == 3:
         return True
-    else:
+    elif err_func.counter == 2:
         raise TypeError
+    else:
+        raise errors.ConnectionFailure
 
 err_func.counter = 0
 
@@ -60,6 +63,12 @@ class TestUtil(unittest.TestCase):
 
         self.assertTrue(retry_until_ok(err_func))
         self.assertEqual(err_func.counter, 3)
+
+        # RuntimeError should not be caught
+        def raise_runtime_error():
+            raise RuntimeError
+        with self.assertRaises(RuntimeError):
+            retry_until_ok(raise_runtime_error)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This prevents rollback from possibly setting the oplog checkpoint to a no-op oplog entry. When this bug is triggered `init_cursor` will infinitely recur (`init_cursor` -> `rollback` -> `init_cursor`) because the no-op checkpoint is filtered out by `get_oplog_cursor`.  Worse, `retry_until_ok` caught all exceptions, including `RuntimeError`, so the maximum recursion depth exceeded was caught and retried. In travis this showed up [as a stalled build](https://travis-ci.org/ShaneHarvey/mongo-connector/jobs/167804286#L652-L656).

Excluding `RuntimeError` confirmed the problem:

```python
Exception in thread Thread-1:
Traceback (most recent call last):
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/threading.py", line 810, in __bootstrap_inner
    self.run()
  File "mongo_connector/util.py", line 92, in wrapped
    func(*args, **kwargs)
  File "mongo_connector/oplog_manager.py", line 331, in run
    cursor, cursor_empty = retry_until_ok(self.init_cursor)
  File "mongo_connector/util.py", line 77, in retry_until_ok
    return func(*args, **kwargs)
  File "mongo_connector/oplog_manager.py", line 898, in init_cursor
    return self.init_cursor()
  File "mongo_connector/oplog_manager.py", line 898, in init_cursor
    return self.init_cursor()

many more calls...

  File "mongo_connector/oplog_manager.py", line 898, in init_cursor
    return self.init_cursor()
  File "mongo_connector/oplog_manager.py", line 897, in init_cursor
    self.update_checkpoint(self.rollback())
  File "mongo_connector/oplog_manager.py", line 1003, in rollback
    sort=[('$natural', pymongo.DESCENDING)]
  File "mongo_connector/util.py", line 77, in retry_until_ok
    return func(*args, **kwargs)
  File "/Users/shane/venv/mongo-connector/python2.7/lib/python2.7/site-packages/pymongo/collection.py", line 1014, in find_one
    for result in cursor.limit(-1):
  File "/Users/shane/venv/mongo-connector/python2.7/lib/python2.7/site-packages/pymongo/cursor.py", line 1090, in next
    if len(self.__data) or self._refresh():
  File "/Users/shane/venv/mongo-connector/python2.7/lib/python2.7/site-packages/pymongo/cursor.py", line 1012, in _refresh
    self.__read_concern))
  File "/Users/shane/venv/mongo-connector/python2.7/lib/python2.7/site-packages/pymongo/cursor.py", line 850, in __send_message
    **kwargs)
  File "/Users/shane/venv/mongo-connector/python2.7/lib/python2.7/site-packages/pymongo/mongo_client.py", line 844, in _send_message_with_response
    exhaust)
  File "/Users/shane/venv/mongo-connector/python2.7/lib/python2.7/site-packages/pymongo/mongo_client.py", line 855, in _reset_on_error
    return func(*args, **kwargs)
  File "/Users/shane/venv/mongo-connector/python2.7/lib/python2.7/site-packages/pymongo/server.py", line 159, in send_message_with_response
    from_command=use_find_cmd)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/contextlib.py", line 24, in __exit__
    self.gen.next()
  File "/Users/shane/venv/mongo-connector/python2.7/lib/python2.7/site-packages/pymongo/server.py", line 164, in get_socket
    yield sock_info
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/contextlib.py", line 24, in __exit__
    self.gen.next()
  File "/Users/shane/venv/mongo-connector/python2.7/lib/python2.7/site-packages/pymongo/pool.py", line 592, in get_socket
    self.return_socket(sock_info)
  File "/Users/shane/venv/mongo-connector/python2.7/lib/python2.7/site-packages/pymongo/pool.py", line 650, in return_socket
    self._socket_semaphore.release()
  File "/Users/shane/venv/mongo-connector/python2.7/lib/python2.7/site-packages/pymongo/thread_util.py", line 86, in release
    return Semaphore.release(self)
  File "/Users/shane/venv/mongo-connector/python2.7/lib/python2.7/site-packages/pymongo/thread_util.py", line 66, in release
    self._cond.notify()
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/threading.py", line 383, in notify
    if not self._is_owned():
RuntimeError: maximum recursion depth exceeded
```

Extracted from #560 to make the bug (and the fix) more visible. 