### PR TITLE
Bug fix: do not call len on None

### DIFF
--- a/mongo_connector/doc_managers/doc_manager_base.py
+++ b/mongo_connector/doc_managers/doc_manager_base.py
@@ -67,8 +67,8 @@ class DocManagerBase(object):
                     if '.' in to_set:
                         path = to_set.split(".")
                         where = _retrieve_path(doc, path[:-1], create=True)
-                        wl = len(where)
                         index = _convert_or_raise(where, path[-1])
+                        wl = len(where)
                         if isinstance(where, list) and index >= wl:
                             where.extend([None] * (index + 1 - wl))
                         where[index] = value


### PR DESCRIPTION
Fixes #517. Instead of halting the OplogThread on a TypeError the unknown update will be logged as an `UpdateDoesNotApply` error.