### PR TITLE
Bug fix: initialize connection to mongos for a sharded OplogThread

### DIFF
--- a/mongo_connector/connector.py
+++ b/mongo_connector/connector.py
@@ -368,7 +368,8 @@ class Connector(threading.Thread):
                         hosts, replicaSet=repl_set)
                     oplog = OplogThread(
                         shard_conn, self.doc_managers, self.oplog_progress,
-                        self.dest_mapping, **self.kwargs)
+                        self.dest_mapping, mongos_client=self.main_conn,
+                        **self.kwargs)
                     self.shard_set[shard_id] = oplog
                     msg = "Starting connection thread"
                     LOG.info("MongoConnector: %s %s" % (msg, shard_conn))


### PR DESCRIPTION
The mongos connection is required to correctly handled a rollback that reverts a chunk migration and a subsequent update one of the migrated documents. In that case the mongos must be used to query the doner shard so that the OplogThread can find the original documents. Caveat: it's unclear if this kind of rollback may even be possible in MongoDB. Either way, using the mongos connection is not any less correct.