### PR TITLE
Add travis link to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,11 @@
+===============
+mongo-connector
+===============
+
+.. image:: https://travis-ci.org/mongodb-labs/mongo-connector.svg?branch=master
+   :alt: View build status
+   :target: https://travis-ci.org/mongodb-labs/mongo-connector
+
 For complete documentation, check out the `Mongo Connector Wiki <https://github.com/10gen-labs/mongo-connector/wiki>`__.
 
 System Overview


### PR DESCRIPTION
See the rendered view here: https://github.com/ShaneHarvey/mongo-connector/blob/add-travis-link/README.rst

Not running the test suite.