### PR TITLE
Bug fix: do not checkpoint the newest oplog entry when noDump is set

### DIFF
--- a/mongo_connector/oplog_manager.py
+++ b/mongo_connector/oplog_manager.py
@@ -882,9 +882,10 @@ class OplogThread(threading.Thread):
                     return None, True
             else:
                 # Collection dump disabled:
-                # return cursor to beginning of oplog.
+                # Return cursor to beginning of oplog but do not set the
+                # checkpoint. The checkpoint will be set after an operation
+                # has been applied.
                 cursor = self.get_oplog_cursor()
-                self.update_checkpoint(self.get_last_oplog_timestamp())
                 return cursor, self._cursor_empty(cursor)
 
         cursor = self.get_oplog_cursor(timestamp)

--- a/tests/test_oplog_manager.py
+++ b/tests/test_oplog_manager.py
@@ -276,16 +276,16 @@ class TestOplogManager(unittest.TestCase):
         self.assertEqual(self.opman.read_last_checkpoint(), last_ts)
 
         # No last checkpoint, no collection dump, something in oplog
+        # If collection dump is false the checkpoint should not be set
         self.opman.checkpoint = None
         self.opman.oplog_progress = LockingDict()
         self.opman.collection_dump = False
         collection.insert_one({"i": 2})
-        last_ts = self.opman.get_last_oplog_timestamp()
         cursor, cursor_empty = self.opman.init_cursor()
         for doc in cursor:
             last_doc = doc
         self.assertEqual(last_doc['o']['i'], 2)
-        self.assertEqual(self.opman.checkpoint, last_ts)
+        self.assertIsNone(self.opman.checkpoint)
 
         # Last checkpoint exists, no collection dump, something in oplog
         collection.insert_many([{"i": i + 500} for i in range(1000)])

--- a/tests/test_oplog_manager_wildcard.py
+++ b/tests/test_oplog_manager_wildcard.py
@@ -286,17 +286,16 @@ class TestOplogManager(unittest.TestCase):
         self.assertEqual(self.opman.read_last_checkpoint(), last_ts)
 
         # No last checkpoint, no collection dump, something in oplog
+        # If collection dump is false the checkpoint should not be set
         self.opman.checkpoint = None
         self.opman.oplog_progress = LockingDict()
         self.opman.collection_dump = False
         collection.insert_one({"idb1col1": 2})
-        last_ts = self.opman.get_last_oplog_timestamp()
         cursor, cursor_empty = self.opman.init_cursor()
         for doc in cursor:
             last_doc = doc
         self.assertEqual(last_doc['o']['idb1col1'], 2)
-        self.assertEqual(self.opman.checkpoint, last_ts)
-        self.assertEqual(self.opman.read_last_checkpoint(), last_ts)
+        self.assertIsNone(self.opman.checkpoint)
 
         # Last checkpoint exists
         collection.insert_many([{"idb1col1": i + 500} for i in range(1000)])


### PR DESCRIPTION
If we checkpoint the newest entry and then the cursor fails, there is a chance that the next cursor created will start at that newest entry (skipping everything in between). The result is that data might be lost when using [`noDump`](https://github.com/mongodb-labs/mongo-connector/wiki/Configuration-Options#nodump).

The fix is to skip creating a checkpoint when the cursor is created and instead let the checkpoint be set in the `run` method normally.

Fixes the bug in #556.