### PR TITLE
Move __version__ out of __init__.py

### DIFF
--- a/mongo_connector/__init__.py
+++ b/mongo_connector/__init__.py
@@ -13,5 +13,3 @@
 # limitations under the License.
 from pkgutil import extend_path
 __path__ = extend_path(__path__, __name__)
-
-__version__ = '2.5.0.dev0'

--- a/mongo_connector/config.py
+++ b/mongo_connector/config.py
@@ -16,7 +16,8 @@ import logging
 import optparse
 import sys
 
-from mongo_connector import compat, errors, __version__
+from mongo_connector import compat, errors
+from mongo_connector.constants import __version__
 from mongo_connector.compat import reraise
 
 

--- a/mongo_connector/constants.py
+++ b/mongo_connector/constants.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
+__version__ = '2.5.0.dev0'
+
 # Maximum # of documents to process before recording timestamp
 # default = -1 (no maximum)
 DEFAULT_BATCH_SIZE = -1


### PR DESCRIPTION
`mongo-connector` and the docManagers all share the same `mongo-connector` module.  This means that if you do:
```
pip install mongo-connector
pip install elastic2-doc-manager
```
 the `__init__py` files of `elastic2-doc-manager` will clobber the existing ones (`mongo_connector/__init__.py` and `mongo_connector/doc_managers/__init__.py`). This means we can't rely on anything inside these files. In my opinion, this should be changed so that third party doc managers live in separate modules. Let's simply not add anything in these files for now.