### PR TITLE
Refactor DestMapping

### DIFF
--- a/config.json
+++ b/config.json
@@ -43,9 +43,12 @@
         "__mapping": {
             "db.source1": "db.dest1",
             "db.source2": "db.dest2",
-            "db2.*": "db2_map_*.dest"
+            "db2.*": "db2.dest_*",
+            "db.col_*": {
+                "rename": "db.new_name_*"
+            }
         },
-	"__gridfs": ["db.fs"]
+        "__gridfs": ["db.fs"]
     },
 
     "docManagers": [

--- a/mongo_connector/connector.py
+++ b/mongo_connector/connector.py
@@ -123,8 +123,7 @@ class Connector(threading.Thread):
         # Replace the origin dest_mapping
         self.dest_mapping = DestMapping(
             kwargs.get('ns_set'), kwargs.get('ex_ns_set'),
-            kwargs.get('dest_mapping'), kwargs.get('fields'),
-            kwargs.get('exclude_fields'))
+            kwargs.get('dest_mapping'))
 
         # Initialize and set the command helper
         command_helper = CommandHelper(self.dest_mapping)

--- a/mongo_connector/dest_mapping.py
+++ b/mongo_connector/dest_mapping.py
@@ -96,16 +96,23 @@ class DestMapping(object):
     def __init__(self, namespace_set=None, ex_namespace_set=None,
                  user_mapping=None, include_fields=None,
                  exclude_fields=None):
-        # a dict containing plain mappings
+        # A mapping from non-wildcard source namespaces to a MappedNamespace
+        # containing the non-wildcard target name.
         self.plain = {}
-        # a list of (RegexObject, MappedNamespace) tuples
-        self.regex_map = []
-        # a dict containing reverse plain mapping
-        # because the mappings are not duplicated,
-        # so the values should also be unique
+        # A mapping from non-wildcard target namespaces to their
+        # corresponding non-wildcard source namespace. Namespaces have a
+        # one-to-one relationship with the target system, meaning multiple
+        # source namespaces cannot be merged into a single namespace in the
+        # target.
         self.reverse_plain = {}
-        # a dict containing plain db mappings, db -> a set of mapped db
+        # A mapping from non-wildcard source database names to the set of
+        # non-wildcard target database names.
         self.plain_db = {}
+        # A list of (re.RegexObject, MappedNamespace) tuples. regex_map maps
+        # wildcard source namespaces to a MappedNamespace containing the
+        # wildcard target name. When a namespace is matched, an entry is
+        # created in `self.plain` for faster subsequent lookups.
+        self.regex_map = []
 
         # Fields to include or exclude from all namespaces
         self.include_fields = include_fields
@@ -120,7 +127,10 @@ class DestMapping(object):
 
         user_mapping = user_mapping or {}
         namespace_set = namespace_set or []
-        # initialize
+        # Add each namespace from the namespace_set and user_mapping
+        # parameters. Namespaces have a one-to-one relationship with the
+        # target system, meaning multiple source namespaces cannot be merged
+        # into a single namespace in the target
         for ns in namespace_set:
             user_mapping.setdefault(ns, ns)
 

--- a/mongo_connector/dest_mapping.py
+++ b/mongo_connector/dest_mapping.py
@@ -117,7 +117,7 @@ class DestMapping(object):
         # Add each namespace from the namespace_set and user_mapping
         # parameters. Namespaces have a one-to-one relationship with the
         # target system, meaning multiple source namespaces cannot be merged
-        # into a single namespace in the target
+        # into a single namespace in the target.
         for ns in namespace_set:
             user_mapping.setdefault(ns, ns)
 

--- a/mongo_connector/dest_mapping.py
+++ b/mongo_connector/dest_mapping.py
@@ -25,15 +25,12 @@ from mongo_connector import errors
 LOG = logging.getLogger(__name__)
 
 
-_MappedNamespace = namedtuple(
-    'MappedNamespace',
-    ['dest_name', 'source_name'])
+_Namespace = namedtuple('Namespace', ['dest_name', 'source_name'])
 
 
-class MappedNamespace(_MappedNamespace):
+class Namespace(_Namespace):
     def __new__(cls, dest_name=None, source_name=None):
-        return super(MappedNamespace, cls).__new__(
-            cls, dest_name, source_name)
+        return super(Namespace, cls).__new__(cls, dest_name, source_name)
 
 
 class RegexSet(MutableSet):
@@ -141,11 +138,11 @@ class DestMapping(object):
     def _add_mapping(self, src_name, dest_name=None):
         if dest_name is None:
             dest_name = src_name
-        self.set(MappedNamespace(dest_name=dest_name, source_name=src_name))
+        self.set(Namespace(dest_name=dest_name, source_name=src_name))
         # Add the namespace for commands on this database
         cmd_name = src_name.split('.', 1)[0] + '.$cmd'
         dest_cmd_name = dest_name.split('.', 1)[0] + '.$cmd'
-        self.set(MappedNamespace(dest_name=dest_cmd_name, source_name=cmd_name))
+        self.set(Namespace(dest_name=dest_cmd_name, source_name=cmd_name))
 
     def set_plain(self, mapped_namespace):
         """A utility function to set the corresponding plain variables"""
@@ -177,7 +174,7 @@ class DestMapping(object):
             return None
         if not self.regex_map and not self.plain:
             # here we include all namespaces
-            return MappedNamespace(plain_src_ns)
+            return Namespace(plain_src_ns)
         # search in plain mappings first
         try:
             return self.plain[plain_src_ns]
@@ -190,7 +187,7 @@ class DestMapping(object):
                                                mapped.dest_name)
                 if not new_name:
                     continue
-                new_mapped = MappedNamespace(
+                new_mapped = Namespace(
                     dest_name=new_name, source_name=plain_src_ns)
                 self.set_plain(new_mapped)
                 return new_mapped

--- a/mongo_connector/dest_mapping.py
+++ b/mongo_connector/dest_mapping.py
@@ -248,26 +248,6 @@ class DestMapping(object):
         self.get(plain_src_db + '.$cmd')
         return list(self.plain_db.get(plain_src_db, set()))
 
-    def fields(self, plain_src_ns):
-        """Get the fields to include and exclude for a given namespace."""
-        mapped = self.get(plain_src_ns)
-        if mapped:
-            return mapped.include_fields, mapped.exclude_fields
-        else:
-            return None, None
-
-    def projection(self, plain_src_name, projection):
-        """For the given source namespace return the projected fields."""
-        include_fields, exclude_fields = self.fields(plain_src_name)
-        fields = include_fields or exclude_fields
-        include = 1 if include_fields else 0
-        if fields:
-            full_projection = dict((field, include) for field in fields)
-            if projection:
-                full_projection.update(projection)
-            return full_projection
-        return projection
-
 
 def match_replace_regex(regex, src_namespace, dest_namespace):
     """Return the new mapped namespace if the src_namespace matches the

--- a/mongo_connector/dest_mapping.py
+++ b/mongo_connector/dest_mapping.py
@@ -15,29 +15,88 @@
 import logging
 import threading
 import re
+
+from collections import namedtuple, MutableSet
+
 from mongo_connector import errors
 
 
 LOG = logging.getLogger(__name__)
 
-"""New structure to handle both plain and
-wildcard mapping namespaces dynamically.
-"""
+
+_MappedNamespace = namedtuple('MappedNamespace',
+                              ['name', 'include_fields', 'exclude_fields'])
 
 
-class DestMapping():
-    def __init__(self, namespace_set, ex_namespace_set, user_mapping):
-        """
-            namespace_set and ex_namespace_set will not be non-empty
-            in the same time.
-            user_mapping should be non-empty together with namespace_set.
-            This assumption has been verified in the get_config_options()
-            in connector.py.
-        """
+class MappedNamespace(_MappedNamespace):
+    def __new__(cls, name=None, include_fields=None, exclude_fields=None):
+        return super(MappedNamespace, cls).__new__(
+            cls, name, include_fields, exclude_fields)
+
+
+class RegexSet(MutableSet):
+    """Set that stores both plain strings and RegexObjects.
+
+    Membership query results are cached so that repeated lookups of the same
+    string are fast.
+    """
+    def __init__(self, regexes, strings):
+        self._regexes = set(regexes)
+        self._plain = set(strings)
+        self._not_found_cache = set()
+
+    def __contains__(self, item):
+        if item in self._not_found_cache:
+            return False
+        if item in self._plain:
+            return True
+        if item in self._regexes:
+            return True
+        for regex in self._regexes:
+            if regex.match(item):
+                self._plain.add(item)
+                return True
+        self._not_found_cache.add(item)
+        return False
+
+    def __iter__(self):
+        for regex in self._regexes:
+            yield regex
+        for string in self._plain:
+            yield string
+
+    def __len__(self):
+        return len(self._regexes) + len(self._plain)
+
+    def add(self, string):
+        self._plain.add(string)
+        self._not_found_cache.discard(string)
+
+    def discard(self, string):
+        self._plain.discard(string)
+
+    @staticmethod
+    def from_namespaces(namespaces):
+        regexes = set()
+        strings = set()
+        for ns in namespaces:
+            if '*' in ns:
+                regexes.add(namespace_to_regex(ns))
+            else:
+                strings.add(ns)
+        return RegexSet(regexes, strings)
+
+
+class DestMapping(object):
+    """Manages included and excluded namespaces.
+    """
+    def __init__(self, namespace_set=None, ex_namespace_set=None,
+                 user_mapping=None, include_fields=None,
+                 exclude_fields=None):
         # a dict containing plain mappings
         self.plain = {}
-        # a dict containing wildcard mappings
-        self.wildcard = {}
+        # a list of (RegexObject, original namespace, MappedNamespace) tuples
+        self.regex_map = []
         # a dict containing reverse plain mapping
         # because the mappings are not duplicated,
         # so the values should also be unique
@@ -45,113 +104,134 @@ class DestMapping():
         # a dict containing plain db mappings, db -> a set of mapped db
         self.plain_db = {}
 
+        # Fields to include or exclude from all namespaces
+        self.include_fields = include_fields
+        self.exclude_fields = exclude_fields
+
         # the input namespace_set and ex_namespace_set could contain wildcard
-        self.namespace_set = namespace_set
-        self.ex_namespace_set = ex_namespace_set
+        self.namespace_set = set()
+        self.ex_namespace_set = RegexSet.from_namespaces(
+            ex_namespace_set or [])
 
         self.lock = threading.Lock()
 
+        user_mapping = user_mapping or {}
+        namespace_set = namespace_set or []
         # initialize
         for ns in namespace_set:
             user_mapping.setdefault(ns, ns)
 
-        for k, v in user_mapping.items():
-            self.set(k, v)
+        for src_name, v in user_mapping.items():
+            if isinstance(v, dict):
+                self._add_mapping(src_name, v.get('rename'))
+            else:
+                self._add_mapping(src_name, v)
 
-    def set_plain(self, key, value):
-        """A utility function to set the corresponding plain variables"""
-        if value in self.reverse_plain:
+    def _add_mapping(self, src_name, dest_name=None, include_fields=None,
+                     exclude_fields=None):
+        if (self.include_fields and exclude_fields or
+                self.exclude_fields and include_fields or
+                include_fields and exclude_fields):
             raise errors.InvalidConfiguration(
-                "Destination namespaces set should not"
-                " contain any duplicates.")
+                "Cannot mix include fields and exclude fields in "
+                "namespace mapping for: '%s'" % (src_name,))
+        if dest_name is None:
+            dest_name = src_name
+        self.set(src_name, MappedNamespace(dest_name, include_fields,
+                                           exclude_fields))
+        # Add the namespace for commands on this database
+        cmd_name = src_name.split('.', 1)[0] + '.$cmd'
+        dest_cmd_name = dest_name.split('.', 1)[0] + '.$cmd'
+        self.set(cmd_name, MappedNamespace(dest_cmd_name))
 
-        db, col = key.split(".", 1)
-        self.plain[key] = value
-        self.reverse_plain[value] = key
-        if col != "$cmd":
-            if db not in self.plain_db:
-                self.plain_db[db] = set([value.split(".")[0]])
-            else:
-                self.plain_db[db].add(value.split(".")[0])
+    def set_plain(self, src_name, mapped_namespace):
+        """A utility function to set the corresponding plain variables"""
+        # The lock is necessary to properly check that multiple namespaces
+        # into a single namespace.
+        with self.lock:
+            target_name = mapped_namespace.name
+            existing_src = self.reverse_plain.get(target_name)
+            if existing_src and existing_src != src_name:
+                raise errors.InvalidConfiguration(
+                    "Multiple namespaces cannot be combined into one target "
+                    "namespace. Trying to map '%s' to '%s' but there already "
+                    "exists a mapping from '%s' to '%s'" %
+                    (src_name, target_name, existing_src, target_name))
 
-    def match(self, src, dst_pattern):
-        """If source string src matches dst, return the matchobject"""
-        reg_pattern = r'\A' + dst_pattern.replace('*', '(.*)') + r'\Z'
-        m = re.match(reg_pattern, src)
-        return m
+            self.plain[src_name] = mapped_namespace
+            self.reverse_plain[target_name] = src_name
+            src_db, _ = src_name.split(".", 1)
+            target_db, _ = target_name.split(".", 1)
+            self.plain_db.setdefault(src_db, set()).add(target_db)
 
-    def match_set(self, plain_src, dst_arr):
-        for x in dst_arr:
-            if plain_src == x:
-                return True
-            if "*" in x:
-                m = self.match(plain_src, x)
-                if m:
-                    return True
-
-        return False
-
-    def replace(self, src_match, map_pattern):
-        """Given the matchobject src_match,
-        replace corresponding '*' in map_pattern with src_match."""
-        wildcard_matched = src_match.group(1)
-        return map_pattern.replace("*", wildcard_matched)
-
-    def get(self, plain_src_ns, defaultval=""):
-        """Given a plain source namespace, return a mapped namespace if matched.
-        If no match and given defaultval, return it as a default value.
+    def get(self, plain_src_ns):
+        """Given a plain source namespace, return a mapped namespace if it
+        should be included or None.
         """
-        with self.lock:
-            # search in plain mappings first
-            try:
-                return self.plain[plain_src_ns]
-            except KeyError:
-                # search in wildcard mappings
-                # if matched, get a replaced mapped namespace
-                # and add to the plain mappings
-                for k, v in self.wildcard.items():
-                    m_res = self.match(plain_src_ns, k)
-                    if m_res:
-                        res = self.replace(m_res, v)
-                        if res is not None:
-                            self.set_plain(plain_src_ns, res)
-                            return res
+        # if plain_src_ns matches ex_namespace_set, ignore
+        if plain_src_ns in self.ex_namespace_set:
+            return None
+        if not self.regex_map and not self.plain:
+            # here we include all namespaces
+            return MappedNamespace(plain_src_ns)
+        # search in plain mappings first
+        try:
+            return self.plain[plain_src_ns]
+        except KeyError:
+            # search in wildcard mappings
+            # if matched, get a replaced mapped namespace
+            # and add to the plain mappings
+            for regex, _, mapped in self.regex_map:
+                new_name = match_replace_regex(regex, plain_src_ns,
+                                               mapped.name)
+                if not new_name:
+                    continue
+                new_mapped = MappedNamespace(new_name,
+                                             mapped.include_fields,
+                                             mapped.exclude_fields)
+                self.set_plain(plain_src_ns, new_mapped)
+                return new_mapped
 
-            if defaultval:
-                return defaultval
-            else:
-                LOG.warn("Failed to find matched mapping "
-                         "for %s." % plain_src_ns)
-                return None
+        self.ex_namespace_set.add(plain_src_ns)
+        return None
 
-    def set(self, key, value):
-        """Set the DestMapping instance to corresponding dictionary"""
-        with self.lock:
-            if "*" in key:
-                self.wildcard[key] = value
-            else:
-                self.set_plain(key, value)
+    def set(self, src_name, mapped_namespace):
+        """Add a new namespace mapping."""
+        if "*" in src_name:
+            self.regex_map.append((namespace_to_regex(src_name),
+                                   src_name, mapped_namespace))
+        else:
+            self.set_plain(src_name, mapped_namespace)
+        self.namespace_set.add(src_name)
 
-    def get_key(self, plain_mapped_ns):
+    def unmap_namespace(self, plain_mapped_ns):
         """Given a plain mapped namespace, return a source namespace if
-        matched. Only need to consider plain mappings since this is only
-        called in rollback and all the rollback namespaces in the target
-        system should already been put in the reverse_plain dictionary.
+        matched. It is possible for the mapped namespace to not yet be present
+        in the plain/reverse_plain dictionaries so we search the wildcard
+        dictionary as well.
         """
-        return self.reverse_plain.get(plain_mapped_ns)
+        if not self.regex_map and not self.plain:
+            return plain_mapped_ns
+
+        src_name = self.reverse_plain.get(plain_mapped_ns)
+        if src_name:
+            return src_name
+        for _, wildcard_ns, mapped in self.regex_map:
+            original_name = match_replace_regex(
+                namespace_to_regex(mapped.name), plain_mapped_ns, wildcard_ns)
+            if original_name:
+                return original_name
+        return None
 
     def map_namespace(self, plain_src_ns):
         """Applies the plain source namespace mapping to a "db.collection" string.
         The input parameter ns is plain text.
         """
-        # if plain_src_ns matches ex_namespace_set, ignore
-        if self.match_set(plain_src_ns, self.ex_namespace_set):
-            return None
-        # if no namespace_set, no renaming
-        if not self.namespace_set:
-            return self.get(plain_src_ns, defaultval=plain_src_ns)
+        mapped = self.get(plain_src_ns)
+        if mapped:
+            return mapped.name
         else:
-            return self.get(plain_src_ns)
+            return None
 
     def map_db(self, plain_src_db):
         """Applies the namespace mapping to a database.
@@ -162,8 +242,47 @@ class DestMapping():
         databases should exist and already been put to plain_db when doing
         create/insert operation.
         """
-
-        if self.plain_db:
-            return list(self.plain_db.get(plain_src_db, set([])))
-        else:
+        if not self.regex_map and not self.plain:
             return [plain_src_db]
+        # Lookup this namespace to seed the plain_db dictionary
+        self.get(plain_src_db + '.$cmd')
+        return list(self.plain_db.get(plain_src_db, set()))
+
+    def fields(self, plain_src_ns):
+        """Get the fields to include and exclude for a given namespace."""
+        mapped = self.get(plain_src_ns)
+        if mapped:
+            return mapped.include_fields, mapped.exclude_fields
+        else:
+            return None, None
+
+    def projection(self, plain_src_name, projection):
+        """For the given source namespace return the projected fields."""
+        include_fields, exclude_fields = self.fields(plain_src_name)
+        fields = include_fields or exclude_fields
+        include = 1 if include_fields else 0
+        if fields:
+            full_projection = dict((field, include) for field in fields)
+            if projection:
+                full_projection.update(projection)
+            return full_projection
+        return projection
+
+
+def match_replace_regex(regex, src_namespace, dest_namespace):
+    """Return the new mapped namespace if the src_namespace matches the
+    regex."""
+    match = regex.match(src_namespace)
+    if match:
+        return dest_namespace.replace('*', match.group(1))
+    return None
+
+
+def namespace_to_regex(namespace):
+    """Create a RegexObject from a wildcard namespace."""
+    if namespace.find('*') < namespace.find('.'):
+        # A database name cannot contain a '.' character
+        wildcard_group = '([^.]*)'
+    else:
+        wildcard_group = '(.*)'
+    return re.compile(r'\A' + namespace.replace('*', wildcard_group) + r'\Z')

--- a/mongo_connector/dest_mapping.py
+++ b/mongo_connector/dest_mapping.py
@@ -285,4 +285,6 @@ def namespace_to_regex(namespace):
         wildcard_group = '([^.]*)'
     else:
         wildcard_group = '(.*)'
-    return re.compile(r'\A' + namespace.replace('*', wildcard_group) + r'\Z')
+    return re.compile(r'\A' +
+                      re.escape(namespace).replace('\*', wildcard_group) +
+                      r'\Z')

--- a/mongo_connector/oplog_manager.py
+++ b/mongo_connector/oplog_manager.py
@@ -235,6 +235,11 @@ class OplogThread(threading.Thread):
             else:
                 return True, False
 
+        # Commands should not be ignored, filtered, or renamed. Renaming is
+        # handled by the DocManagers via the CommandHelper class.
+        if coll == ".$cmd":
+            return False, False
+
         # Rename or filter out namespaces that are ignored keeping
         # included gridfs namespaces.
         new_ns = self.dest_mapping_stru.map_namespace(ns)

--- a/mongo_connector/oplog_manager.py
+++ b/mongo_connector/oplog_manager.py
@@ -24,7 +24,6 @@ except ImportError:
 import sys
 import time
 import threading
-import re
 
 import pymongo
 
@@ -112,17 +111,8 @@ class OplogThread(threading.Thread):
         # Represents the last checkpoint for a OplogThread.
         self.oplog_progress = oplog_progress_dict
 
-        # The set of namespaces to process from the mongo cluster.
-        self.namespace_set = kwargs.get('ns_set', [])
-
-        # The set of namespaces not to process from the mongo cluster.
-        self.ex_namespace_set = kwargs.get('ex_ns_set', [])
-
         # The set of gridfs namespaces to process from the mongo cluster
         self.gridfs_set = kwargs.get('gridfs_set', [])
-
-        # The dict of source namespaces to destination namespaces
-        self.dest_mapping = kwargs.get('dest_mapping', {})
 
         # The structure handling dest_mappings dynamically
         self.dest_mapping_stru = dest_mapping_stru
@@ -144,7 +134,7 @@ class OplogThread(threading.Thread):
 
         if not self.oplog.find_one():
             err_msg = 'OplogThread: No oplog for thread:'
-            LOG.warning('%s %s' % (err_msg, self.primary_connection))
+            LOG.warning('%s %s' % (err_msg, self.primary_client))
 
     @property
     def fields(self):
@@ -195,24 +185,6 @@ class OplogThread(threading.Thread):
             self._projection = None
 
     @property
-    def namespace_set(self):
-        return self._namespace_set
-
-    @namespace_set.setter
-    def namespace_set(self, namespace_set):
-        self._namespace_set = namespace_set
-        self.update_oplog_ns_set()
-
-    @property
-    def ex_namespace_set(self):
-        return self._ex_namespace_set
-
-    @ex_namespace_set.setter
-    def ex_namespace_set(self, ex_namespace_set):
-        self._ex_namespace_set = ex_namespace_set
-        self.update_oplog_ex_ns_set()
-
-    @property
     def gridfs_set(self):
         return self._gridfs_set
 
@@ -220,7 +192,6 @@ class OplogThread(threading.Thread):
     def gridfs_set(self, gridfs_set):
         self._gridfs_set = gridfs_set
         self._gridfs_files_set = [ns + '.files' for ns in gridfs_set]
-        self.update_oplog_ns_set()
 
     @property
     def gridfs_files_set(self):
@@ -228,33 +199,6 @@ class OplogThread(threading.Thread):
             return self._gridfs_files_set
         except AttributeError:
             return []
-
-    @property
-    def oplog_ns_set(self):
-        try:
-            return self._oplog_ns_set
-        except AttributeError:
-            return []
-
-    def update_oplog_ns_set(self):
-        self._oplog_ns_set = []
-        if self.namespace_set:
-            for ns in self.namespace_set:
-                self._oplog_ns_set.append(ns)
-                self._oplog_ns_set.append(ns.split('.', 1)[0] + '.$cmd')
-
-            self._oplog_ns_set.extend(self.gridfs_files_set)
-            self._oplog_ns_set.append("admin.$cmd")
-
-    @property
-    def oplog_ex_ns_set(self):
-        return self._oplog_ex_ns_set
-
-    def update_oplog_ex_ns_set(self):
-        self._oplog_ex_ns_set = []
-        if self.ex_namespace_set:
-            for ens in self.ex_namespace_set:
-                self._oplog_ex_ns_set.append(ens)
 
     def _should_skip_entry(self, entry):
         """Determine if this oplog entry should be skipped.
@@ -291,28 +235,20 @@ class OplogThread(threading.Thread):
             else:
                 return True, False
 
-        # Ignore the collection if it is not included.
-        # It is not possible to have include and exclude at the same time.
-        if (self.oplog_ns_set and not self.oplog_ex_ns_set and not
-                self.dest_mapping_stru.match_set(ns, self.oplog_ns_set)):
-            LOG.debug("OplogThread: Skipping oplog entry: "
-                      "'%s' is not in the namespace set." % (ns,))
-            return True, False
-        if (self.oplog_ex_ns_set and not self.oplog_ns_set and
-                self.dest_mapping_stru.match_set(ns, self.oplog_ex_ns_set)):
-            LOG.debug("OplogThread: Skipping oplog entry: "
-                      "'%s' is in the exclude namespace set." % (ns,))
-            return True, False
-
-        # use namespace mapping if one exists
-        ns = self.dest_mapping_stru.get(ns, ns)
-        if ns is None:
-            LOG.debug("OplogThread: Skipping oplog entry: "
-                      "'%s' is not in the namespace set." % (ns,))
-            return True, False
+        # Rename or filter out namespaces that are ignored keeping
+        # included gridfs namespaces.
+        new_ns = self.dest_mapping_stru.map_namespace(ns)
+        if new_ns is None:
+            if is_gridfs_file:
+                # Gridfs files should not be skipped
+                new_ns = ns
+            else:
+                LOG.debug("OplogThread: Skipping oplog entry: "
+                          "'%s' is not in the namespace set." % (ns,))
+                return True, False
 
         # update the namespace
-        entry['ns'] = ns
+        entry['ns'] = new_ns
 
         # Take fields out of the oplog entry that shouldn't be replicated.
         # This may nullify the document if there's nothing to do.
@@ -648,53 +584,32 @@ class OplogThread(threading.Thread):
                     if coll.endswith(".files") or coll.endswith(".chunks"):
                         continue
                     namespace = "%s.%s" % (database, coll)
-                    all_ns_set.append(namespace)
+                    if self.dest_mapping_stru.map_namespace(namespace):
+                        all_ns_set.append(namespace)
             return all_ns_set
 
-        def get_ns_from_set(namespace_set, include=True):
-            all_ns_set = get_all_ns()
-            ns_set = []
-            for src_ns in all_ns_set:
-                for map_ns in namespace_set:
-                    # get all matched collections in that ns
-                    reg_pattern = r'\A' + map_ns.replace('*', '(.*)') + r'\Z'
-                    if re.match(reg_pattern, src_ns):
-                        ns_set.append(src_ns)
-                        continue
-
-            if include:
-                return ns_set
-            else:
-                return [x for x in all_ns_set if x not in ns_set]
-
-        # No namespaces specified
-        if (not self.namespace_set) and (not self.ex_namespace_set):
-            dump_set = get_all_ns()
-        elif self.namespace_set and not self.ex_namespace_set:
-            dump_set = get_ns_from_set(self.namespace_set)
-        else:
-            # ex_namespace_set is set but no namespace_set
-            dump_set = get_ns_from_set(self.ex_namespace_set, include=False)
+        dump_set = get_all_ns()
 
         LOG.debug("OplogThread: Dumping set of collections %s " % dump_set)
 
-        def docs_to_dump(from_coll):
+        def docs_to_dump(from_coll, source_namespace):
             last_id = None
             attempts = 0
-
+            projection = self.dest_mapping_stru.projection(source_namespace,
+                                                           self._projection)
             # Loop to handle possible AutoReconnect
             while attempts < 60:
                 if last_id is None:
                     cursor = retry_until_ok(
                         from_coll.find,
-                        projection=self._projection,
+                        projection=projection,
                         sort=[("_id", pymongo.ASCENDING)]
                     )
                 else:
                     cursor = retry_until_ok(
                         from_coll.find,
                         {"_id": {"$gt": last_id}},
-                        projection=self._projection,
+                        projection=projection,
                         sort=[("_id", pymongo.ASCENDING)]
                     )
                 try:
@@ -716,12 +631,11 @@ class OplogThread(threading.Thread):
             num_failed = 0
             for namespace in dump_set:
                 from_coll = self.get_collection(namespace)
+                mapped_ns = self.dest_mapping_stru.map_namespace(namespace)
                 total_docs = retry_until_ok(from_coll.count)
                 num = None
-                for num, doc in enumerate(docs_to_dump(from_coll)):
+                for num, doc in enumerate(docs_to_dump(from_coll, namespace)):
                     try:
-                        mapped_ns = self.dest_mapping_stru.get(namespace,
-                                                               namespace)
                         dm.upsert(doc, mapped_ns, long_ts)
                     except Exception:
                         if self.continue_on_error:
@@ -746,12 +660,13 @@ class OplogThread(threading.Thread):
                 for namespace in dump_set:
                     from_coll = self.get_collection(namespace)
                     total_docs = retry_until_ok(from_coll.count)
-                    mapped_ns = self.dest_mapping_stru.get(namespace,
-                                                           namespace)
+                    mapped_ns = self.dest_mapping_stru.map_namespace(
+                            namespace)
                     LOG.info("Bulk upserting approximately %d docs from "
                              "collection '%s'",
                              total_docs, namespace)
-                    dm.bulk_upsert(docs_to_dump(from_coll), mapped_ns, long_ts)
+                    dm.bulk_upsert(docs_to_dump(from_coll, namespace),
+                                   mapped_ns, long_ts)
             except Exception:
                 if self.continue_on_error:
                     LOG.exception("OplogThread: caught exception"
@@ -771,8 +686,8 @@ class OplogThread(threading.Thread):
                 for gridfs_ns in self.gridfs_set:
                     mongo_coll = self.get_collection(gridfs_ns)
                     from_coll = self.get_collection(gridfs_ns + '.files')
-                    dest_ns = self.dest_mapping_stru.get(gridfs_ns, gridfs_ns)
-                    for doc in docs_to_dump(from_coll):
+                    dest_ns = self.dest_mapping_stru.map_namespace(gridfs_ns)
+                    for doc in docs_to_dump(from_coll, gridfs_ns):
                         gridfile = GridFSFile(mongo_coll, doc)
                         dm.insert_file(gridfile, dest_ns, long_ts)
             except:
@@ -1031,7 +946,8 @@ class OplogThread(threading.Thread):
             # or removing them in each target system
             for namespace, doc_list in rollback_set.items():
                 # Get the original namespace
-                original_namespace = self.dest_mapping_stru.get_key(namespace)
+                original_namespace = self.dest_mapping_stru.unmap_namespace(
+                    namespace)
                 if not original_namespace:
                     original_namespace = namespace
 
@@ -1044,7 +960,8 @@ class OplogThread(threading.Thread):
                 to_update = util.retry_until_ok(
                     client[database][coll].find,
                     {'_id': {'$in': bson_obj_id_list}},
-                    projection=self._projection
+                    projection=self.dest_mapping_stru.projection(
+                        original_namespace, self._projection)
                 )
                 # Doc list are docs in target system, to_update are
                 # Docs in mongo
@@ -1092,8 +1009,7 @@ class OplogThread(threading.Thread):
                     try:
                         insert_inc += 1
                         dm.upsert(doc,
-                                  self.dest_mapping_stru.get(namespace,
-                                                             namespace),
+                                  namespace,
                                   util.bson_ts_to_long(rollback_cutoff_ts))
                     except errors.OperationFailed:
                         fail_insert_inc += 1

--- a/tests/test_command_replication.py
+++ b/tests/test_command_replication.py
@@ -68,21 +68,17 @@ class TestCommandReplication(unittest.TestCase):
         close_client(self.primary_conn)
         self.repl_set.stop()
 
-    def initOplogThread(self, namespace_set=[], ex_namespace_set=[],
-                        dest_mapping={}):
+    def initOplogThread(self, namespace_set=None):
         self.docman = CommandLoggerDocManager()
         # Replace the origin dest_mapping
-        self.dest_mapping_stru = DestMapping(namespace_set, ex_namespace_set,
-                                             dest_mapping)
+        dest_mapping = DestMapping(namespace_set=namespace_set)
 
-        self.docman.command_helper = CommandHelper(self.dest_mapping_stru)
+        self.docman.command_helper = CommandHelper(dest_mapping)
         self.opman = OplogThread(
             primary_client=self.primary_conn,
             doc_managers=(self.docman,),
             oplog_progress_dict=self.oplog_progress,
-            dest_mapping_stru=self.dest_mapping_stru,
-            ns_set=namespace_set,
-            ex_ns_set=ex_namespace_set,
+            dest_mapping_stru=dest_mapping,
             collection_dump=False
         )
         self.opman.start()
@@ -94,10 +90,8 @@ class TestCommandReplication(unittest.TestCase):
             'a.y': 'c.y'
         }
 
-        # Replace the origin dest_mapping
-        dest_mapping_stru = DestMapping(list(mapping) + ['a.z'], [], mapping)
-
-        helper = CommandHelper(dest_mapping_stru)
+        helper = CommandHelper(DestMapping(
+            namespace_set=list(mapping) + ['a.z'], user_mapping=mapping))
 
         self.assertEqual(set(helper.map_db('a')), set(['a', 'b', 'c']))
         self.assertEqual(helper.map_db('d'), [])

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -520,10 +520,9 @@ class TestConnectorConfig(unittest.TestCase):
         self.assertEqual(mc.ssl_kwargs.get('ssl_cert_reqs'),
                          self.config['ssl.sslCertificatePolicy'])
         command_helper = mc.doc_managers[0].command_helper
-        self.assertEqual(command_helper.dest_mapping_stru.namespace_set,
-                         self.config['namespaces.include'])
-        self.assertEqual(command_helper.dest_mapping_stru.plain,
-                         self.config['namespaces.mapping'])
+        for name in self.config['namespaces.mapping']:
+            self.assertTrue(
+                command_helper.dest_mapping_stru.map_namespace(name))
 
         # Test Logger options.
         log_levels = [

--- a/tests/test_dest_mapping.py
+++ b/tests/test_dest_mapping.py
@@ -54,7 +54,7 @@ class TestDestMapping(unittest.TestCase):
                              "db1.col1")
             self.assertEqual(dest_mapping.unmap_namespace("db1.col1"),
                              "db1.col1")
-            self.assertEqual(dest_mapping.get("db1.col1"),
+            self.assertEqual(dest_mapping.lookup("db1.col1"),
                              Namespace(dest_name="db1.col1",
                                        source_name="db1.col1"))
             self.assertListEqual(dest_mapping.map_db("db1"), ["db1"])

--- a/tests/test_dest_mapping.py
+++ b/tests/test_dest_mapping.py
@@ -12,104 +12,156 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import re
+
 from tests import unittest
-from mongo_connector.dest_mapping import DestMapping
+from mongo_connector.dest_mapping import (
+    DestMapping, MappedNamespace, match_replace_regex, namespace_to_regex,
+    RegexSet)
 from mongo_connector import errors
 
 
 class TestDestMapping(unittest.TestCase):
-    def setup_mapping(self, include, exclude, mapping):
-        self.mapping = DestMapping(include, exclude, mapping)
+    """Test the DestMapping class"""
 
     def test_default(self):
-        # By default, all namespaces are kept without renaming
-        self.setup_mapping([], [], {})
-        self.assertEqual(self.mapping.get("db1.col1", "db1.col1"), "db1.col1")
-        self.assertFalse(self.mapping.get_key("db1.col1"))
-        self.assertListEqual(self.mapping.map_db("db1"), ["db1"])
-        self.assertEqual(self.mapping.map_namespace("db1.col1"), "db1.col1")
+        """Test that by default, all namespaces are kept without renaming"""
+        dest_mapping = DestMapping()
+        self.assertEqual(dest_mapping.unmap_namespace("db1.col1"), "db1.col1")
+        self.assertEqual(dest_mapping.map_db("db1"), ["db1"])
+        self.assertEqual(dest_mapping.map_namespace("db1.col1"), "db1.col1")
 
-    def test_only_include(self):
-        # Test that only provides include namespaces
+    def test_include_plain(self):
+        """Test including namespaces without wildcards"""
+        dest_mapping = DestMapping(namespace_set=["db1.col1", "db1.col2"])
+        self.assertEqual(dest_mapping.unmap_namespace("db1.col1"), "db1.col1")
+        self.assertEqual(dest_mapping.unmap_namespace("db1.col2"), "db1.col2")
+        self.assertIsNone(dest_mapping.unmap_namespace("not.included"))
+        self.assertEqual(dest_mapping.map_db("db1"), ["db1"])
+        self.assertEqual(dest_mapping.map_db("not_included"), [])
+        self.assertEqual(dest_mapping.map_namespace("db1.col1"), "db1.col1")
+        self.assertEqual(dest_mapping.map_namespace("db1.col2"), "db1.col2")
+        self.assertIsNone(dest_mapping.map_namespace("db1.col4"))
 
-        # Test plain case
-        self.setup_mapping(["db1.col1", "db1.col2", "db1.col3"], [], {})
-        self.assertEqual(self.mapping.get("db1.col1"), "db1.col1")
-        self.assertEqual(self.mapping.get("db1.col2"), "db1.col2")
-        self.assertEqual(self.mapping.get("db1.col3"), "db1.col3")
-        self.assertEqual(self.mapping.get_key("db1.col1"), "db1.col1")
-        self.assertListEqual(self.mapping.map_db("db1"), ["db1"])
-        self.assertEqual(self.mapping.map_namespace("db1.col1"), "db1.col1")
-        self.assertIsNone(self.mapping.map_namespace("db1.col4"))
+    def test_include_wildcard(self):
+        """Test including namespaces with wildcards"""
+        equivalent_dest_mappings = (
+            DestMapping(namespace_set=["db1.*"]),
+            DestMapping(user_mapping={"db1.*": {}}),
+            DestMapping(user_mapping={"db1.*": {"rename": "db1.*"}}))
+        for dest_mapping in equivalent_dest_mappings:
+            self.assertEqual(dest_mapping.unmap_namespace("db1.col1"),
+                             "db1.col1")
+            self.assertEqual(dest_mapping.unmap_namespace("db1.col1"),
+                             "db1.col1")
+            self.assertEqual(dest_mapping.get("db1.col1"),
+                             MappedNamespace("db1.col1"))
+            self.assertListEqual(dest_mapping.map_db("db1"), ["db1"])
+            self.assertEqual(dest_mapping.map_namespace("db1.col1"),
+                             "db1.col1")
+            self.assertIsNone(dest_mapping.map_namespace("db2.col4"))
 
-        # Test wildcard case
-        self.setup_mapping(["db1.*"], [], {})
-        self.assertFalse(self.mapping.get_key("db1.col1"))
-        self.assertEqual(self.mapping.get("db1.col1"), "db1.col1")
-        self.assertEqual(self.mapping.get_key("db1.col1"), "db1.col1")
-        self.assertListEqual(self.mapping.map_db("db1"), ["db1"])
-        self.assertEqual(self.mapping.map_namespace("db1.col1"), "db1.col1")
-        self.assertIsNone(self.mapping.map_namespace("db2.col4"))
+    def test_include_wildcard_no_period_in_database(self):
+        """Test that a database wildcard cannot match a period."""
+        dest_mapping = DestMapping(namespace_set=["db*.col"])
+        self.assertIsNone(dest_mapping.map_namespace("db.bar.col"))
 
-    def test_only_exclude(self):
-        # Test that only provides exclude namespaces
+    def test_exclude_plain(self):
+        """Test excluding namespaces without wildcards"""
+        dest_mapping = DestMapping(ex_namespace_set=["ex.clude"])
+        self.assertEqual(dest_mapping.unmap_namespace("db.col"), "db.col")
+        self.assertEqual(dest_mapping.unmap_namespace("ex.clude"), "ex.clude")
+        self.assertEqual(dest_mapping.map_namespace("db.col"), "db.col")
+        self.assertIsNone(dest_mapping.map_namespace("ex.clude"))
 
-        # Test plain case
-        self.setup_mapping([], ["db1.col4"], {})
-        self.assertEqual(self.mapping.get("db1.col1", "db1.col1"), "db1.col1")
-        self.assertEqual(self.mapping.map_namespace("db1.col1"), "db1.col1")
-        self.assertIsNone(self.mapping.map_namespace("db1.col4"))
+    def test_exclude_wildcard(self):
+        """Test excluding namespaces with wildcards"""
+        dest_mapping = DestMapping(ex_namespace_set=["ex.*"])
+        self.assertEqual(dest_mapping.unmap_namespace("db.col"), "db.col")
+        self.assertEqual(dest_mapping.unmap_namespace("ex.clude"), "ex.clude")
+        self.assertEqual(dest_mapping.map_namespace("db.col"), "db.col")
+        self.assertIsNone(dest_mapping.map_namespace("ex.clude"))
+        self.assertIsNone(dest_mapping.map_namespace("ex.clude2"))
 
-        # Test wildcard case
-        self.setup_mapping([], ["db2.*"], {})
-        self.assertEqual(self.mapping.get("db1.col1", "db1.col1"), "db1.col1")
-        self.assertEqual(self.mapping.map_namespace("db1.col1"), "db1.col1")
-        self.assertIsNone(self.mapping.map_namespace("db2.col"))
+    def test_unmap_namespace_wildcard(self):
+        """Test un-mapping a namespace that was never explicitly mapped."""
+        dest_mapping = DestMapping(user_mapping={
+            "db2.*": "db2.f*",
+            "db_*.foo": "db_new_*.foo",
+        })
+        self.assertEqual(dest_mapping.unmap_namespace("db2.foo"), "db2.oo")
+        self.assertEqual(dest_mapping.unmap_namespace("db_new_123.foo"),
+                         "db_123.foo")
 
-    def test_mapping(self):
-        # mulitple dbs cannot be mapped to the same db
-        mapping = {
-          "db1.col1": "newdb.newcol",
-          "db2.col1": "newdb.newcol"
-        }
-        self.assertRaises(errors.InvalidConfiguration, self.setup_mapping,
-                          ["db1.col1", "db2.col1"], [], mapping)
+    def test_rename_validation(self):
+        """Test namespace renaming validation."""
+        # Multiple collections cannot be merged into the same target namespace
+        with self.assertRaises(errors.InvalidConfiguration):
+            DestMapping(user_mapping={
+                "db1.col1": "newdb.newcol",
+                "db2.col1": "newdb.newcol"})
+        # Multiple collections cannot be merged into the same target namespace
+        with self.assertRaises(errors.InvalidConfiguration):
+            dest_mapping = DestMapping(user_mapping={
+                "db*.col1": "newdb.newcol*",
+                "db*.col2": "newdb.newcol*"})
+            dest_mapping.map_namespace("db1.col1")
+            dest_mapping.map_namespace("db1.col2")
 
-        # Test mapping
-        mapping = {
-          "db1.*": "newdb1_*.newcol",
-          "db2.a": "newdb2_a.x",
-          "db2.b": "b_newdb2.x"
-        }
-        self.setup_mapping(["db1.*", "db2.a", "db2.b"], [], mapping)
-        self.assertDictEqual(self.mapping.plain,
-                             {"db2.a": "newdb2_a.x", "db2.b": "b_newdb2.x"})
-        self.assertDictEqual(self.mapping.plain_db,
-                             {"db2": set(["newdb2_a", "b_newdb2"])})
-        self.assertDictEqual(self.mapping.reverse_plain,
-                             {"newdb2_a.x": "db2.a", "b_newdb2.x": "db2.b"})
-        self.assertDictEqual(self.mapping.wildcard,
-                             {"db1.*": "newdb1_*.newcol"})
-        self.assertEqual(self.mapping.get_key("newdb2_a.x"), "db2.a")
-        self.assertSetEqual(set(self.mapping.map_db("db2")),
-                            set(["newdb2_a", "b_newdb2"]))
-        # when we get matched maps, plain should contain those ones afterwards
-        self.assertEqual(self.mapping.get("db1.col1"), "newdb1_col1.newcol")
-        self.assertEqual(self.mapping.map_namespace("db1.col2"),
-                         "newdb1_col2.newcol")
-        self.assertDictEqual(self.mapping.plain,
-                             {"db2.a": "newdb2_a.x",
-                              "db2.b": "b_newdb2.x",
-                              "db1.col1": "newdb1_col1.newcol",
-                              "db1.col2": "newdb1_col2.newcol"})
-        self.assertDictEqual(self.mapping.plain_db,
-                             {"db2": set(["newdb2_a", "b_newdb2"]),
-                              "db1": set(["newdb1_col1", "newdb1_col2"])})
-        self.assertDictEqual(self.mapping.reverse_plain,
-                             {"newdb2_a.x": "db2.a",
-                              "b_newdb2.x": "db2.b",
-                              "newdb1_col1.newcol": "db1.col1",
-                              "newdb1_col2.newcol": "db1.col2"})
+    def test_match_replace_regex(self):
+        """Test regex matching and replacing."""
+        regex = re.compile(r"\Adb_([^.]*).foo\Z")
+        self.assertIsNone(match_replace_regex(regex, "db.foo", "*.foo"))
+        self.assertIsNone(match_replace_regex(regex, "db.foo.foo", "*.foo"))
+        self.assertEqual(match_replace_regex(regex, "db_bar.foo", "*.foo"),
+                         "bar.foo")
 
-if __name__ == '__main__':
+    def test_namespace_to_regex(self):
+        """Test regex creation."""
+        self.assertEqual(namespace_to_regex("db_*.foo"),
+                         re.compile(r"\Adb_([^.]*).foo\Z"))
+        self.assertEqual(namespace_to_regex("db.foo*"),
+                         re.compile(r"\Adb.foo(.*)\Z"))
+        self.assertEqual(namespace_to_regex("db.foo"),
+                         re.compile(r"\Adb.foo\Z"))
+
+
+class TestRegexSet(unittest.TestCase):
+    """Test the RegexSet class."""
+
+    def test_from_namespaces(self):
+        """Test construction from list of namespaces."""
+        self.assertEqual(RegexSet.from_namespaces([]),
+                         RegexSet([], []))
+        self.assertEqual(RegexSet.from_namespaces(["db.bar", "db_*.foo",
+                                                   "db2.*"]),
+                         RegexSet([namespace_to_regex("db_*.foo"),
+                                   namespace_to_regex("db2.*")],
+                                  ["db.bar"]))
+
+    def test_contains(self):
+        """Test membership query."""
+        regex_set = RegexSet.from_namespaces(["db.bar", "db_*.foo", "db2.*"])
+        self.assertTrue("db.bar" in regex_set)
+        self.assertTrue("db_1.foo" in regex_set)
+        self.assertTrue("db2.bar" in regex_set)
+        self.assertTrue("db2.bar2" in regex_set)
+        self.assertFalse("not.found" in regex_set)
+        self.assertFalse("db_not.found" in regex_set)
+
+    def test_add(self):
+        """Test adding a new string."""
+        regex_set = RegexSet.from_namespaces([])
+        self.assertFalse("string.found" in regex_set)
+        regex_set.add("string.found")
+        self.assertTrue("string.found" in regex_set)
+
+    def test_discard(self):
+        """Test discarding a string."""
+        regex_set = RegexSet.from_namespaces(["db.bar"])
+        self.assertTrue("db.bar" in regex_set)
+        regex_set.discard("db.bar")
+        self.assertFalse("db.bar" in regex_set)
+
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_dest_mapping.py
+++ b/tests/test_dest_mapping.py
@@ -91,29 +91,24 @@ class TestDestMapping(unittest.TestCase):
         dest_mapping = DestMapping(namespace_set=["db.*"])
         self.assertIsNone(dest_mapping.map_namespace("dbxcol"))
         self.assertEqual(dest_mapping.map_namespace("db.col"), "db.col")
-        self.assertEqual(dest_mapping.map_namespace("db.$cmd"), "db.$cmd")
 
     def test_include_wildcard_multiple_periods(self):
         """Test matching a namespace with multiple '.' characters."""
         dest_mapping = DestMapping(namespace_set=["db.col.*"])
         self.assertIsNone(dest_mapping.map_namespace("db.col"))
         self.assertEqual(dest_mapping.map_namespace("db.col."), "db.col.")
-        self.assertEqual(dest_mapping.map_namespace("db.$cmd"), "db.$cmd")
 
     def test_include_wildcard_no_period_in_database(self):
         """Test that a database wildcard cannot match a period."""
         dest_mapping = DestMapping(namespace_set=["db*.col"])
         self.assertIsNone(dest_mapping.map_namespace("db.bar.col"))
         self.assertEqual(dest_mapping.map_namespace("dbfoo.col"), "dbfoo.col")
-        self.assertEqual(dest_mapping.map_namespace("db2.$cmd"), "db2.$cmd")
 
     def test_include_wildcard_metacharacters(self):
         """Test namespaces with metacharacters are matched."""
         dest_mapping = DestMapping(namespace_set=["db&_*.$_^_#_!_[_]_"])
         self.assertEqual(dest_mapping.map_namespace("db&_foo.$_^_#_!_[_]_"),
                          "db&_foo.$_^_#_!_[_]_")
-        self.assertEqual(dest_mapping.map_namespace("db&_bar.$cmd"),
-                         "db&_bar.$cmd")
         self.assertIsNone(dest_mapping.map_namespace("db&.foo"))
 
     def test_exclude_plain(self):

--- a/tests/test_dest_mapping.py
+++ b/tests/test_dest_mapping.py
@@ -55,7 +55,8 @@ class TestDestMapping(unittest.TestCase):
             self.assertEqual(dest_mapping.unmap_namespace("db1.col1"),
                              "db1.col1")
             self.assertEqual(dest_mapping.get("db1.col1"),
-                             MappedNamespace("db1.col1"))
+                             MappedNamespace(dest_name="db1.col1",
+                                             source_name="db1.col1"))
             self.assertListEqual(dest_mapping.map_db("db1"), ["db1"])
             self.assertEqual(dest_mapping.map_namespace("db1.col1"),
                              "db1.col1")

--- a/tests/test_dest_mapping.py
+++ b/tests/test_dest_mapping.py
@@ -16,7 +16,7 @@ import re
 
 from tests import unittest
 from mongo_connector.dest_mapping import (
-    DestMapping, MappedNamespace, match_replace_regex, namespace_to_regex,
+    DestMapping, Namespace, match_replace_regex, namespace_to_regex,
     RegexSet, wildcards_overlap)
 from mongo_connector import errors
 
@@ -55,8 +55,8 @@ class TestDestMapping(unittest.TestCase):
             self.assertEqual(dest_mapping.unmap_namespace("db1.col1"),
                              "db1.col1")
             self.assertEqual(dest_mapping.get("db1.col1"),
-                             MappedNamespace(dest_name="db1.col1",
-                                             source_name="db1.col1"))
+                             Namespace(dest_name="db1.col1",
+                                       source_name="db1.col1"))
             self.assertListEqual(dest_mapping.map_db("db1"), ["db1"])
             self.assertEqual(dest_mapping.map_namespace("db1.col1"),
                              "db1.col1")

--- a/tests/test_dest_mapping.py
+++ b/tests/test_dest_mapping.py
@@ -61,10 +61,35 @@ class TestDestMapping(unittest.TestCase):
                              "db1.col1")
             self.assertIsNone(dest_mapping.map_namespace("db2.col4"))
 
+    def test_include_wildcard_periods(self):
+        """Test the '.' in the namespace only matches '.'"""
+        dest_mapping = DestMapping(namespace_set=["db.*"])
+        self.assertIsNone(dest_mapping.map_namespace("dbxcol"))
+        self.assertEqual(dest_mapping.map_namespace("db.col"), "db.col")
+        self.assertEqual(dest_mapping.map_namespace("db.$cmd"), "db.$cmd")
+
+    def test_include_wildcard_multiple_periods(self):
+        """Test matching a namespace with multiple '.' characters."""
+        dest_mapping = DestMapping(namespace_set=["db.col.*"])
+        self.assertIsNone(dest_mapping.map_namespace("db.col"))
+        self.assertEqual(dest_mapping.map_namespace("db.col."), "db.col.")
+        self.assertEqual(dest_mapping.map_namespace("db.$cmd"), "db.$cmd")
+
     def test_include_wildcard_no_period_in_database(self):
         """Test that a database wildcard cannot match a period."""
         dest_mapping = DestMapping(namespace_set=["db*.col"])
         self.assertIsNone(dest_mapping.map_namespace("db.bar.col"))
+        self.assertEqual(dest_mapping.map_namespace("dbfoo.col"), "dbfoo.col")
+        self.assertEqual(dest_mapping.map_namespace("db2.$cmd"), "db2.$cmd")
+
+    def test_include_wildcard_metacharacters(self):
+        """Test namespaces with metacharacters are matched."""
+        dest_mapping = DestMapping(namespace_set=["db&_*.$_^_#_!_[_]_"])
+        self.assertEqual(dest_mapping.map_namespace("db&_foo.$_^_#_!_[_]_"),
+                         "db&_foo.$_^_#_!_[_]_")
+        self.assertEqual(dest_mapping.map_namespace("db&_bar.$cmd"),
+                         "db&_bar.$cmd")
+        self.assertIsNone(dest_mapping.map_namespace("db&.foo"))
 
     def test_exclude_plain(self):
         """Test excluding namespaces without wildcards"""
@@ -118,12 +143,19 @@ class TestDestMapping(unittest.TestCase):
 
     def test_namespace_to_regex(self):
         """Test regex creation."""
-        self.assertEqual(namespace_to_regex("db_*.foo"),
-                         re.compile(r"\Adb_([^.]*).foo\Z"))
+        self.assertEqual(namespace_to_regex("db*.foo"),
+                         re.compile(r"\Adb([^.]*)\.foo\Z"))
         self.assertEqual(namespace_to_regex("db.foo*"),
-                         re.compile(r"\Adb.foo(.*)\Z"))
+                         re.compile(r"\Adb\.foo(.*)\Z"))
         self.assertEqual(namespace_to_regex("db.foo"),
-                         re.compile(r"\Adb.foo\Z"))
+                         re.compile(r"\Adb\.foo\Z"))
+
+    def test_namespace_to_regex_escapes_metacharacters(self):
+        """Test regex creation escapes metacharacters."""
+        self.assertEqual(namespace_to_regex("db&*.$a^a#a!a[a]a"),
+                         re.compile(r"\Adb\&([^.]*)\.\$a\^a\#a\!a\[a\]a\Z"))
+        self.assertEqual(namespace_to_regex("db.$a^a#a!a[a]a*"),
+                         re.compile(r"\Adb\.\$a\^a\#a\!a\[a\]a(.*)\Z"))
 
 
 class TestRegexSet(unittest.TestCase):

--- a/tests/test_dest_mapping.py
+++ b/tests/test_dest_mapping.py
@@ -139,19 +139,13 @@ class TestDestMapping(unittest.TestCase):
 
         # Multiple collections cannot be merged into the same target namespace
         dest_mapping = DestMapping(user_mapping={
-            "d*.coll": "d*.coll",
-            "db1.c*l": "db.c*l"})
+            "*.coll": "*.new_coll",
+            "db.*": "new_db.*"})
+        dest_mapping.map_namespace("new_db.coll")
         with self.assertRaises(errors.InvalidConfiguration):
-            dest_mapping.map_namespace("db.coll")
-            dest_mapping.map_namespace("db1.coll")
-
-        # Multiple collections cannot be merged into the same target namespace
-        dest_mapping = DestMapping(user_mapping={
-            "*.important_coll": "*.super_important_coll",
-            "important_db.*": "super_important_db.*"})
-        with self.assertRaises(errors.InvalidConfiguration):
-            dest_mapping.map_namespace("super_important_db.important_coll")
-            dest_mapping.map_namespace("important_db.super_important_coll")
+            # "db.new_coll" should map to "new_db.new_coll" but there is
+            # already a mapping from "new_db.coll" to "new_db.new_coll".
+            dest_mapping.map_namespace("db.new_coll")
 
         # For the sake of map_db, wildcards cannot be moved from database name
         # to collection name.

--- a/tests/test_mongo_doc_manager.py
+++ b/tests/test_mongo_doc_manager.py
@@ -245,14 +245,12 @@ class TestMongoDocManager(MongoTestCase):
         # Also test with namespace mapping.
         # Note that mongo-connector does not currently support commands after
         # renaming a database.
-        dest_mapping_stru = DestMapping(['test.test',
-                                         'test.test2',
-                                         'test.drop'],
-                                        [],
-                                        {
-                                         'test.test': 'test.othertest',
-                                         'test.drop': 'dropped.collection'
-                                        })
+        dest_mapping_stru = DestMapping(
+            namespace_set=['test.test', 'test.test2', 'test.drop'],
+            user_mapping={
+             'test.test': 'test.othertest',
+             'test.drop': 'dropped.collection'
+            })
         self.choosy_docman.command_helper = CommandHelper(dest_mapping_stru)
 
         try:

--- a/tests/test_oplog_manager_sharded.py
+++ b/tests/test_oplog_manager_sharded.py
@@ -126,13 +126,13 @@ class ShardedClusterTestCase(unittest.TestCase):
         # Oplog threads (oplog manager) for each shard
         doc_manager = DocManager()
         oplog_progress = LockingDict()
-        dest_mapping_stru = DestMapping(["test.mcsharded", "test.mcunsharded"], [], {})
+        dest_mapping_stru = DestMapping(
+            namespace_set=["test.mcsharded", "test.mcunsharded"])
         self.opman1 = OplogThread(
             primary_client=self.shard1_conn,
             doc_managers=(doc_manager,),
             oplog_progress_dict=oplog_progress,
             dest_mapping_stru=dest_mapping_stru,
-            ns_set=["test.mcsharded", "test.mcunsharded"],
             mongos_client=self.mongos_conn
         )
         self.opman2 = OplogThread(
@@ -140,7 +140,6 @@ class ShardedClusterTestCase(unittest.TestCase):
             doc_managers=(doc_manager,),
             oplog_progress_dict=oplog_progress,
             dest_mapping_stru=dest_mapping_stru,
-            ns_set=["test.mcsharded", "test.mcunsharded"],
             mongos_client=self.mongos_conn
         )
 

--- a/tests/test_oplog_manager_wildcard.py
+++ b/tests/test_oplog_manager_wildcard.py
@@ -53,9 +53,7 @@ class TestOplogManager(unittest.TestCase):
             primary_client=self.primary_conn,
             doc_managers=(DocManager(),),
             oplog_progress_dict=LockingDict(),
-            dest_mapping_stru=self.dest_mapping_stru,
-            ns_set=include_ns,
-            ex_ns_set=exclude_ns
+            dest_mapping_stru=self.dest_mapping_stru
         )
 
     def init_dbs(self):

--- a/tests/test_oplog_manager_wildcard.py
+++ b/tests/test_oplog_manager_wildcard.py
@@ -310,17 +310,15 @@ class TestOplogManager(unittest.TestCase):
         1. in namespace set, mapping provided
         2. outside of namespace set, mapping provided
         """
-
-        source_ns_wildcard = ["includedb1.*", "includedb2.includecol1"]
-        source_ns = ["includedb1.includecol1",
-                     "includedb1.includecol2",
-                     "includedb2.includecol1"]
-        phony_ns = ["includedb2.excludecol2", "excludedb3.excludecol1"]
+        included_names = ["includedb1.includecol1",
+                          "includedb1.includecol2",
+                          "includedb2.includecol1"]
+        excluded_names = ["includedb2.excludecol2", "excludedb3.excludecol1"]
         dest_mapping = {
-                        "includedb1.*": "newdb1_*.bar",
-                        "includedb2.includecol1": "newdb2.newcol1"
-                        }
-        self.reset_opman(source_ns_wildcard, [], dest_mapping)
+            "includedb1.*": "newdb1.*",
+            "includedb2.includecol1": "newdb2.newcol1"
+        }
+        self.reset_opman(dest_mapping=dest_mapping)
         docman = self.opman.doc_managers[0]
         dest_mapping_stru = self.opman.dest_mapping_stru
 
@@ -329,8 +327,7 @@ class TestOplogManager(unittest.TestCase):
 
         base_doc = {"_id": 1, "name": "superman"}
 
-        # doc in namespace set
-        for ns in source_ns:
+        for ns in included_names:
             db, coll = ns.split(".", 1)
 
             # test insert
@@ -372,7 +369,7 @@ class TestOplogManager(unittest.TestCase):
             self.opman.doc_managers[0]._delete()
 
         # doc not in namespace set
-        for ns in phony_ns:
+        for ns in excluded_names:
             db, coll = ns.split(".", 1)
 
             # test insert

--- a/tests/test_rollbacks.py
+++ b/tests/test_rollbacks.py
@@ -74,13 +74,11 @@ class TestRollbacks(unittest.TestCase):
         # Oplog thread
         doc_manager = DocManager()
         oplog_progress = LockingDict()
-        dest_mapping_stru = DestMapping(["test.mc"], [], {})
         self.opman = OplogThread(
             primary_client=self.main_conn,
             doc_managers=(doc_manager,),
             oplog_progress_dict=oplog_progress,
-            dest_mapping_stru=dest_mapping_stru,
-            ns_set=["test.mc"]
+            dest_mapping_stru=DestMapping(namespace_set=["test.mc"]),
         )
 
     def test_single_target(self):


### PR DESCRIPTION
DestMapping now includes command namespaces, eg including "db.col" should
also include "db.$cmd".
Improve regex matching by creating RegexObjects and caching lookups.
Update the config parsing with a new format for "namespaces.mapping". It's no longer required to repeat namespaces if you're using "namespaces.include" and "namespaces.mapping". Add a dictionary format which will be extended later to support additional fields per namespace (eg "includeFields"/"excludeFields"):

```json
{
 "namespaces": {
        "mapping": {
            "db.source1": "db.dest1",
            "db2.*": "db2.dest_*",
            "db.col_*": {
                "rename": "db.new_name_*"
            }
        }
}
```
Before this change such a config would look like:
```json
{
 "namespaces": {
        "include": ["db.source1", "db2.*", "db.col_*"],
        "mapping": {
            "db.source1": "db.dest1",
            "db2.*": "db2.dest_*",
            "db.col_*": "db.new_name_*"
        }
}
```


Fixes bugs with the original implementation:
- wildcards in database names no longer can match the '.' character
- escape metacharacters when converting to regex (fixes https://github.com/mongodb-labs/mongo-connector/issues/600).
- `map_db` and `unmap_namespace` now work with wildcards regardless if the
  original namespace was previously mapped already.
- OplogThread now calls `map_namespace` instead of `get`.
- Gridfs files should now be synced properly.
- In rollback logic, the namespace from the DocManager should not be re-mapped.