### PR TITLE
Add integration tests for renaming namespaces with the MongoDB DocManager

### DIFF
--- a/mongo_connector/doc_managers/mongo_doc_manager.py
+++ b/mongo_connector/doc_managers/mongo_doc_manager.py
@@ -70,7 +70,6 @@ class DocManager(DocManagerBase):
             raise errors.ConnectionFailed("Invalid URI for MongoDB")
         except pymongo.errors.ConnectionFailure:
             raise errors.ConnectionFailed("Failed to connect to MongoDB")
-        self.namespace_set = kwargs.get("namespace_set")
         self.chunk_size = kwargs.get('chunk_size', constants.DEFAULT_MAX_BULK)
         self.use_single_meta_collection = kwargs.get(
             'use_single_meta_collection',
@@ -114,9 +113,6 @@ class DocManager(DocManagerBase):
     def _namespaces(self):
         """Provides the list of namespaces being replicated to MongoDB
         """
-        if self.namespace_set:
-            return self.namespace_set
-
         user_namespaces = []
         db_list = self.mongo.database_names()
         for database in db_list:

--- a/mongo_connector/doc_managers/mongo_doc_manager.py
+++ b/mongo_connector/doc_managers/mongo_doc_manager.py
@@ -116,7 +116,8 @@ class DocManager(DocManagerBase):
         if self.use_single_meta_collection:
             yield self.meta_collection_name
         else:
-            for name in self.meta_database.collection_names():
+            for name in self.meta_database.collection_names(
+                    include_system_collections=False):
                 yield name
 
     def stop(self):

--- a/mongo_connector/oplog_manager.py
+++ b/mongo_connector/oplog_manager.py
@@ -237,7 +237,7 @@ class OplogThread(threading.Thread):
 
         # Commands should not be ignored, filtered, or renamed. Renaming is
         # handled by the DocManagers via the CommandHelper class.
-        if coll == ".$cmd":
+        if coll == "$cmd":
             return False, False
 
         # Rename or filter out namespaces that are ignored keeping

--- a/tests/test_mongo.py
+++ b/tests/test_mongo.py
@@ -120,10 +120,10 @@ class TestMongo(MongoTestCase):
 
     def drop_all_databases(self):
         for name in self.mongo_conn.database_names():
-            if name != "local":
+            if name not in ["local", "admin"]:
                 self.mongo_conn.drop_database(name)
         for name in self.conn.database_names():
-            if name != "local":
+            if name not in ["local", "admin"]:
                 self.conn.drop_database(name)
 
     def test_insert(self):

--- a/tests/test_mongo.py
+++ b/tests/test_mongo.py
@@ -94,6 +94,7 @@ class TestMongo(MongoTestCase):
 
     def tearDown(self):
         self.connector.join()
+        self.drop_all_databases()
 
     def setUp(self):
         try:
@@ -103,17 +104,27 @@ class TestMongo(MongoTestCase):
         self._remove()
         self.connector = Connector(
             mongo_address=self.repl_set.uri,
-            ns_set=['test.test'],
+            ns_set=['test.test', 'rename.me'],
+            dest_mapping={'rename.me': 'new.target',
+                          'rename.me2': 'new2.target2'},
             doc_managers=(self.mongo_doc,),
             gridfs_set=['test.test'],
             **connector_opts
         )
 
-        self.conn.drop_database('test')
+        self.drop_all_databases()
 
         self.connector.start()
         assert_soon(lambda: len(self.connector.shard_set) > 0)
         assert_soon(lambda: sum(1 for _ in self._search()) == 0)
+
+    def drop_all_databases(self):
+        for name in self.mongo_conn.database_names():
+            if name != "local":
+                self.mongo_conn.drop_database(name)
+        for name in self.conn.database_names():
+            if name != "local":
+                self.conn.drop_database(name)
 
     def test_insert(self):
         """Tests insert
@@ -203,6 +214,55 @@ class TestMongo(MongoTestCase):
 
         # Update whole document
         check_update({"a": 0, "b": {"1": {"d": 10000}}})
+
+    def check_renamed_insert(self, target_coll):
+        target_db, target_coll = target_coll.split('.', 1)
+        mongo_target = self.mongo_conn[target_db][target_coll]
+        assert_soon(lambda: len(list(mongo_target.find({}))))
+        target_docs = list(mongo_target.find({}))
+        self.assertEqual(len(target_docs), 1)
+        self.assertEqual(target_docs[0]["renamed"], 1)
+
+    def create_renamed_collection(self, source_coll, target_coll):
+        """Create renamed collections for the command tests."""
+        # Create the rename database and 'rename.me' collection
+        source_db, source_coll = source_coll.split('.', 1)
+        mongo_source = self.conn[source_db][source_coll]
+        mongo_source.insert_one({"renamed": 1})
+        self.check_renamed_insert(target_coll)
+
+    def test_drop_database_renamed(self):
+        """Test the dropDatabase command on a renamed database."""
+        self.create_renamed_collection("rename.me", "new.target")
+        self.create_renamed_collection("rename.me2", "new2.target2")
+        # test that drop database removes target databases
+        self.conn.drop_database("rename")
+        assert_soon(lambda: "new" not in self.mongo_conn.database_names())
+        assert_soon(lambda: "new2" not in self.mongo_conn.database_names())
+
+    def test_drop_collection_renamed(self):
+        """Test the drop collection command on a renamed collection."""
+        self.create_renamed_collection("rename.me", "new.target")
+        self.create_renamed_collection("rename.me2", "new2.target2")
+        # test that drop collection removes target collection
+        self.conn.rename.drop_collection("me")
+        assert_soon(
+            lambda: "target" not in self.mongo_conn.new.collection_names())
+        self.conn.rename.drop_collection("me2")
+        assert_soon(
+            lambda: "target2" not in self.mongo_conn.new2.collection_names())
+
+    def test_rename_collection_renamed(self):
+        """Test the renameCollection command on a renamed collection to a
+        renamed collection.
+        """
+        self.create_renamed_collection("rename.me", "new.target")
+        self.conn.admin.command(
+            "renameCollection", "rename.me", to="rename.me2")
+        # In the target, 'new.target' should be renamed to 'new2.target2'
+        assert_soon(
+            lambda: "target" not in self.mongo_conn.new.collection_names())
+        self.check_renamed_insert("new2.target2")
 
     def test_rollback(self):
         """Tests rollback. We force a rollback by adding a doc, killing the

--- a/tests/test_mongo_doc_manager.py
+++ b/tests/test_mongo_doc_manager.py
@@ -54,18 +54,23 @@ class TestMongoDocManager(MongoTestCase):
             db, coll = ns.split('.', 1)
             conn[db][coll].drop()
 
-    def test_namespaces(self):
-        """Ensure that a DocManager returns the correct set of replicated
-        namespaces
+    def test_meta_collections(self):
+        """Ensure that a DocManager returns the correct set of meta collection
+        names.
         """
-        # Before replication no namespaces should be returned
-        self.assertEqual(set(self.choosy_docman._namespaces()), set())
-        self.choosy_docman.upsert({"_id": "1"}, *TESTARGS)
-        self.assertEqual(set(self.choosy_docman._namespaces()),
-                         set(["test.test"]))
-        self.choosy_docman.upsert({"_id": "1"}, "foo.bar", 1)
-        self.assertEqual(set(self.choosy_docman._namespaces()),
-                         set(["test.test", "foo.bar"]))
+        meta_collection_names = set()
+        if self.use_single_meta_collection:
+            meta_collection_names.add(self.choosy_docman.meta_collection_name)
+        # Before replication only the single meta_collection should be
+        # returned.
+        self.assertEqual(set(self.choosy_docman._meta_collections()),
+                         meta_collection_names)
+        for namespace in ["test.test", "foo.bar", "test.bar"]:
+            if not self.use_single_meta_collection:
+                meta_collection_names.add(namespace)
+            self.choosy_docman.upsert({"_id": "1"}, namespace, 1)
+            self.assertEqual(set(self.choosy_docman._meta_collections()),
+                             meta_collection_names)
 
     def test_update(self):
         doc_id = '1'


### PR DESCRIPTION
This change adds integration tests for MongoDB to MongoDB command replication on renamed namespaces and fixes the replication of such commands because of the typo in '$cmd' added here https://github.com/mongodb-labs/mongo-connector/pull/601/files#diff-9e5fc676a1f3b77e19871877266b4cf0R240.

Also, removes the `namespace_set` attribute from the MongoDB DocManager which is never initialized. `namespace_set` was added in version 1.2 https://github.com/mongodb-labs/mongo-connector/commit/bdfe9aad2db8b4adb6616b22fcc71a4e24feb26b but the initialization seems to have been unintentionally removed in version 2.0 https://github.com/mongodb-labs/mongo-connector/commit/6b8a6649e9008397ef2eb4fe1183541b90e2de5b#diff-ca51c2fabfa279cb1d2902ff6c2d8152L371