### PR TITLE
Fix compatability of CommandHelper

### DIFF
--- a/mongo_connector/command_helper.py
+++ b/mongo_connector/command_helper.py
@@ -17,11 +17,15 @@
 
 import logging
 
+from mongo_connector.namespace_config import NamespaceConfig
+
 LOG = logging.getLogger(__name__)
 
 
 class CommandHelper(object):
-    def __init__(self, namespace_config):
+    def __init__(self, namespace_config=None):
+        if namespace_config is None:
+            namespace_config = NamespaceConfig()
         self.namespace_config = namespace_config
 
     # Applies the namespace mapping to a database.


### PR DESCRIPTION
This change makes it valid to create a `CommandHelper` with no arguments.

https://github.com/mongodb-labs/mongo-connector/commit/40c535ae04c1a142f48ad5f3f14a50cb4509fb54#diff-5cdb7eb2a77533aaa7a1bfdc12804cb5L25 Made it invalid to construct a `CommandHelper()` with no arguments which causes the doc manager tests fail https://travis-ci.org/ShaneHarvey/elastic2-doc-manager/jobs/185243250#L780-L785
