### PR TITLE
Fixed ssl_cert_reqs, especially when 'ignored'

### DIFF
--- a/mongo_connector/connector.py
+++ b/mongo_connector/connector.py
@@ -112,13 +112,13 @@ class Connector(threading.Thread):
         ssl_keyfile = kwargs.pop('ssl_keyfile', None)
         ssl_cert_reqs = kwargs.pop('ssl_cert_reqs', None)
         self.ssl_kwargs = {}
-        if ssl_certfile:
+        if ssl_certfile is not None:
             self.ssl_kwargs['ssl_certfile'] = ssl_certfile
-        if ssl_ca_certs:
+        if ssl_ca_certs is not None:
             self.ssl_kwargs['ssl_ca_certs'] = ssl_ca_certs
-        if ssl_keyfile:
+        if ssl_keyfile is not None:
             self.ssl_kwargs['ssl_keyfile'] = ssl_keyfile
-        if ssl_cert_reqs:
+        if ssl_cert_reqs is not None:
             self.ssl_kwargs['ssl_cert_reqs'] = ssl_cert_reqs
 
         # Save the rest of kwargs.
@@ -1056,8 +1056,9 @@ def get_config_options():
         option.value.setdefault('sslCertfile', ssl_certfile)
         option.value.setdefault('sslCACerts', ssl_ca_certs)
         option.value.setdefault('sslKeyfile', ssl_keyfile)
+        option.value.setdefault('sslCertificatePolicy', ssl_cert_reqs)
         option.value['sslCertificatePolicy'] = _SSL_POLICY_MAP.get(
-            ssl_cert_reqs)
+            option.value['sslCertificatePolicy'])
     ssl = add_option(
         config_key="ssl",
         default={},

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -415,7 +415,7 @@ class TestConnectorConfig(unittest.TestCase):
             "sslCertfile": "certfile.pem",
             "sslKeyfile": "certfile.key",
             "sslCACerts": "ca.pem",
-            "sslCertificatePolicy": "required"
+            "sslCertificatePolicy": "optional"
         },
 
         "fields": ["field1", "field2", "field3"],
@@ -469,7 +469,7 @@ class TestConnectorConfig(unittest.TestCase):
         '-g', 'foo2.bar2,fiz2.biz2',
         '--ssl-certfile', 'certfile2.pem',
         '--ssl-ca-certs', 'ca2.pem',
-        '--ssl-certificate-policy', 'optional'
+        '--ssl-certificate-policy', 'ignored'
     ]
 
     # Set of files to keep in the 'lib' directory after each run.


### PR DESCRIPTION
This is meant to fix the `sslCertificatePolicy` option, which is partly broken because:
- Setting `ssl.sslCertificatePolicy` in the config doesn't work. Only the CLI option is actually used
- Even if the CLI option is specified, it isn't passed to the `MongoClient` if it's set to `'ignored'`, because the value maps to `0` (`if ssl_cert_reqs:` doesn't happen)