### PR TITLE
Filter fields per namespace and unify namespace options

### DIFF
--- a/config.json
+++ b/config.json
@@ -37,18 +37,41 @@
 
     "__fields": ["field1", "field2", "field3"],
 
-    "namespaces": {
-        "__include": ["db.source1", "db.source2", "db2.*"],
-        "__exclude": ["db3.source1", "db3.*"],
-        "__mapping": {
-            "db.source1": "db.dest1",
-            "db.source2": "db.dest2",
-            "db2.*": "db2.dest_*",
-            "db.col_*": {
-                "rename": "db.new_name_*"
-            }
+    "__namespaces": {
+        "excluded.collection": false,
+        "excluded_wildcard.*": false,
+        "*.exclude_collection_from_every_database": false,
+        "included.collection1": true,
+        "included.collection2": {},
+        "included.collection4": {
+            "includeFields": ["included_field", "included.nested.field"]
         },
-        "__gridfs": ["db.fs"]
+        "included.collection5": {
+            "rename": "included.new_collection5_name",
+            "includeFields": ["included_field", "included.nested.field"]
+        },
+        "included.collection6": {
+            "excludeFields": ["excluded_field", "excluded.nested.field"]
+        },
+        "included.collection7": {
+            "rename": "included.new_collection7_name",
+            "excludeFields": ["excluded_field", "excluded.nested.field"]
+        },
+        "included_wildcard1.*": true,
+        "included_wildcard2.*": true,
+        "renamed.collection1": "something.else1",
+        "renamed.collection2": {
+            "rename": "something.else2"
+        },
+        "renamed_wildcard.*": {
+            "rename": "new_name.*"
+        },
+        "gridfs.collection": {
+            "gridfs": true
+        },
+        "gridfs_wildcard.*": {
+            "gridfs": true
+        }
     },
 
     "docManagers": [

--- a/mongo_connector/connector.py
+++ b/mongo_connector/connector.py
@@ -14,6 +14,7 @@
 """Discovers the MongoDB cluster and starts the connector.
 """
 
+import copy
 import json
 import logging
 import logging.handlers
@@ -36,7 +37,8 @@ from mongo_connector.doc_managers import doc_manager_simulator as simulator
 from mongo_connector.doc_managers.doc_manager_base import DocManagerBase
 from mongo_connector.command_helper import CommandHelper
 from mongo_connector.util import log_fatal_exceptions, retry_until_ok
-from mongo_connector.namespace_config import NamespaceConfig
+from mongo_connector.namespace_config import (NamespaceConfig,
+                                              validate_namespace_options)
 
 from pymongo import MongoClient
 
@@ -127,8 +129,14 @@ class Connector(threading.Thread):
         # The namespace configuration shared by all OplogThreads and
         # DocManagers
         self.namespace_config = NamespaceConfig(
-            kwargs.get('ns_set'), kwargs.get('ex_ns_set'),
-            kwargs.get('dest_mapping'))
+            namespace_set=kwargs.get('ns_set'),
+            ex_namespace_set=kwargs.get('ex_ns_set'),
+            gridfs_set=kwargs.get('gridfs_set'),
+            dest_mapping=kwargs.get('dest_mapping'),
+            namespace_options=kwargs.get('namespace_options'),
+            include_fields=kwargs.get('fields'),
+            exclude_fields=kwargs.get('exclude_fields')
+        )
 
         # Initialize and set the command helper
         command_helper = CommandHelper(self.namespace_config)
@@ -185,6 +193,7 @@ class Connector(threading.Thread):
             ns_set=config['namespaces.include'],
             ex_ns_set=config['namespaces.exclude'],
             dest_mapping=config['namespaces.mapping'],
+            namespace_options=config['namespaces.namespace_options'],
             gridfs_set=config['namespaces.gridfs'],
             ssl_certfile=config['ssl.sslCertfile'],
             ssl_keyfile=config['ssl.sslKeyfile'],
@@ -732,84 +741,76 @@ def get_config_options():
         "exported. Supports dot notation for document fields but cannot span "
         "arrays. Cannot use both 'fields' and 'exclude_fields'.")
 
-    def apply_namespaces(option, cli_values):
-        if cli_values['ns_set']:
-            option.value['include'] = cli_values['ns_set'].split(',')
+    def merge_namespaces_cli(option, cli_values):
+        def validate_no_duplicates(lst, list_name):
+            if len(lst) != len(set(lst)):
+                raise errors.InvalidConfiguration(
+                    "%s should not contain any duplicates." % (list_name,))
 
-        if cli_values['ex_ns_set']:
-            option.value['exclude'] = cli_values['ex_ns_set'].split(',')
+        if cli_values["ns_set"]:
+            option.value["include"] = cli_values["ns_set"].split(",")
 
-        if cli_values['gridfs_set']:
-            option.value['gridfs'] = cli_values['gridfs_set'].split(',')
+        if cli_values["ex_ns_set"]:
+            option.value["exclude"] = cli_values["ex_ns_set"].split(",")
 
-        if cli_values['dest_ns_set']:
-            ns_set = option.value['include']
-            dest_ns_set = cli_values['dest_ns_set'].split(',')
+        if cli_values["gridfs_set"]:
+            option.value["gridfs"] = cli_values["gridfs_set"].split(",")
+
+        if cli_values["dest_ns_set"]:
+            ns_set = option.value["include"]
+            dest_ns_set = cli_values["dest_ns_set"].split(",")
             if len(ns_set) != len(dest_ns_set):
                 raise errors.InvalidConfiguration(
                     "Destination namespace set should be the"
                     " same length as the origin namespace set.")
-            option.value['mapping'] = dict(zip(ns_set, dest_ns_set))
+            option.value["mapping"] = dict(zip(ns_set, dest_ns_set))
+
+        # Check for duplicates
+        if option.value["include"]:
+            validate_no_duplicates(option.value["include"],
+                                   "Include namespace set")
+        if option.value["exclude"]:
+            validate_no_duplicates(option.value["exclude"],
+                                   "Exclude namespace set")
+        if option.value["gridfs"]:
+            validate_no_duplicates(option.value["gridfs"],
+                                   "GridFS namespace set")
+        if option.value["mapping"]:
+            validate_no_duplicates(list(option.value["mapping"].values()),
+                                   "Destination namespace set")
+
+    def apply_namespaces(option, cli_values):
+        if (option.value['include'] or option.value['exclude'] or
+                option.value['mapping'] or option.value['gridfs']):
+            return apply_disjoint_namespace_options(option, cli_values)
+        else:
+            return apply_unified_namespace_options(option, cli_values)
+
+    def apply_unified_namespace_options(option, cli_values):
+        merge_namespaces_cli(option, cli_values)
+        namespace_options = copy.deepcopy(option.value)
+        ns_set = namespace_options.pop('include', None)
+        ex_ns_set = namespace_options.pop('exclude', None)
+        gridfs_set = namespace_options.pop('gridfs', None)
+        dest_mapping = namespace_options.pop('mapping', None)
+        option.value["namespace_options"] = namespace_options
+
+        validate_namespace_options(
+            namespace_set=ns_set, ex_namespace_set=ex_ns_set,
+            dest_mapping=dest_mapping,
+            namespace_options=namespace_options, gridfs_set=gridfs_set)
+
+    def apply_disjoint_namespace_options(option, cli_values):
+        merge_namespaces_cli(option, cli_values)
 
         ns_set = option.value['include']
-        if len(ns_set) != len(set(ns_set)):
-            raise errors.InvalidConfiguration(
-                "Namespace set should not contain any duplicates.")
-
         ex_ns_set = option.value['exclude']
-        if len(ex_ns_set) != len(set(ex_ns_set)):
-            raise errors.InvalidConfiguration(
-                "Exclude namespace set should not contain any duplicates.")
-
-        # not allow to exist both 'include' and 'exclude'
-        if ns_set and ex_ns_set:
-            raise errors.InvalidConfiguration(
-                "Cannot use both namespace 'include' "
-                "(--namespace-set) and 'exclude' "
-                "(--exclude-namespace-set).")
-
-        # validate 'include' format
-        for ns in ns_set:
-            if ns.count("*") > 1:
-                raise errors.InvalidConfiguration(
-                    "Namespace set should be plain text "
-                    "e.g. foo.bar or only contains one wildcard, e.g. foo.* .")
-
-        # validate 'exclude' format
-        for ens in ex_ns_set:
-            if ens.count("*") > 1:
-                raise errors.InvalidConfiguration(
-                    "Exclude namespace set should be plain text "
-                    "e.g. foo.bar or only contains one wildcard, e.g. foo.* .")
-
-        dest_mapping = option.value['mapping']
-        if len(dest_mapping) != len(set(dest_mapping.values())):
-            raise errors.InvalidConfiguration(
-                "Destination namespaces set should not"
-                " contain any duplicates.")
-
-        for source_name, value in dest_mapping.items():
-            # Mapping may be old style with only a target name, eg:
-            # "db.source": "db.dest",
-            # or new style which can support extra options per namespace:
-            # "db.source": {"rename": "db.dest", ...}
-            if isinstance(value, dict):
-                dest_name = value.get("rename", source_name)
-            else:
-                dest_name = value
-            if source_name.count("*") > 1 or dest_name.count("*") > 1:
-                raise errors.InvalidConfiguration(
-                    "The namespace mapping source and destination "
-                    "cannot contain more than one '*' character.")
-            if source_name.count("*") != dest_name.count("*"):
-                raise errors.InvalidConfiguration(
-                    "The namespace mapping source and destination "
-                    "must contain the same number of '*' characters.")
-
         gridfs_set = option.value['gridfs']
-        if len(gridfs_set) != len(set(gridfs_set)):
-            raise errors.InvalidConfiguration(
-                "GridFS set should not contain any duplicates.")
+        dest_mapping = option.value['mapping']
+
+        validate_namespace_options(
+            namespace_set=ns_set, ex_namespace_set=ex_ns_set,
+            dest_mapping=dest_mapping, gridfs_set=gridfs_set)
 
     default_namespaces = {
         "include": [],

--- a/mongo_connector/namespace_config.py
+++ b/mongo_connector/namespace_config.py
@@ -19,22 +19,32 @@ from collections import namedtuple, MutableSet
 from itertools import combinations
 
 from mongo_connector import errors
+from mongo_connector import compat
 
 
 LOG = logging.getLogger(__name__)
 
 
-_Namespace = namedtuple('Namespace', ['dest_name', 'source_name',
+_Namespace = namedtuple('Namespace', ['dest_name', 'source_name', 'gridfs',
                                       'include_fields', 'exclude_fields'])
 
 
 class Namespace(_Namespace):
-    def __new__(cls, dest_name=None, source_name=None, include_fields=None,
-                exclude_fields=None):
+    def __new__(cls, dest_name=None, source_name=None, gridfs=False,
+                include_fields=None, exclude_fields=None):
         include_fields = set(include_fields or [])
         exclude_fields = set(exclude_fields or [])
         return super(Namespace, cls).__new__(
-            cls, dest_name, source_name, include_fields, exclude_fields)
+            cls, dest_name, source_name, gridfs, include_fields,
+            exclude_fields)
+
+    def with_options(self, **kwargs):
+        new_options = dict(
+            dest_name=self.dest_name, source_name=self.source_name,
+            gridfs=self.gridfs, include_fields=self.include_fields,
+            exclude_fields=self.exclude_fields)
+        new_options.update(kwargs)
+        return Namespace(**new_options)
 
 
 class RegexSet(MutableSet):
@@ -94,7 +104,8 @@ class NamespaceConfig(object):
     """Manages included and excluded namespaces.
     """
     def __init__(self, namespace_set=None, ex_namespace_set=None,
-                 user_mapping=None, include_fields=None, exclude_fields=None):
+                 gridfs_set=None, dest_mapping=None, namespace_options=None,
+                 include_fields=None, exclude_fields=None):
         # A mapping from non-wildcard source namespaces to a MappedNamespace
         # containing the non-wildcard target name.
         self._plain = {}
@@ -117,71 +128,46 @@ class NamespaceConfig(object):
         self._include_fields = validate_include_fields(include_fields)
         self._exclude_fields = validate_exclude_fields(exclude_fields)
 
-        # The set of namespaces to exclude. Can contain wildcard namespaces.
-        self._ex_namespace_set = RegexSet.from_namespaces(
-            ex_namespace_set or [])
+        # Add each included namespace. Namespaces have a one-to-one
+        # relationship to the target system, meaning multiple source
+        # namespaces cannot be merged into a single namespace in the target.
+        ex_namespace_set, namespaces = validate_namespace_options(
+            namespace_set=namespace_set,
+            ex_namespace_set=ex_namespace_set,
+            gridfs_set=gridfs_set,
+            dest_mapping=dest_mapping,
+            namespace_options=namespace_options,
+            include_fields=include_fields,
+            exclude_fields=exclude_fields)
 
-        user_mapping = user_mapping or {}
-        namespace_set = namespace_set or []
-        # Add each namespace from the namespace_set and user_mapping
-        # parameters. Namespaces have a one-to-one relationship with the
-        # target system, meaning multiple source namespaces cannot be merged
-        # into a single namespace in the target.
-        for ns in namespace_set:
-            user_mapping.setdefault(ns, ns)
+        # The set of, possibly wildcard, namespaces to exclude.
+        self._ex_namespace_set = RegexSet.from_namespaces(ex_namespace_set)
 
-        renames = {}
-        for src_name, v in user_mapping.items():
-            include_fields, exclude_fields = None, None
-            if isinstance(v, dict):
-                target_name = v.get('rename', src_name)
-                include_fields = v.get('fields')
-                exclude_fields = v.get('excludeFields')
-            else:
-                target_name = v
-            renames[src_name] = target_name
-            self._add_collection(src_name, target_name, include_fields,
-                                 exclude_fields)
-        validate_target_namespaces(renames)
+        for namespace in namespaces:
+            self._register_namespace_and_command(namespace)
 
-    def _add_collection(self, src_name, dest_name, include_fields,
-                        exclude_fields):
-        """Add the collection name and the corresponding command namespace."""
-        include_fields = include_fields or []
-        exclude_fields = exclude_fields or []
-        if (self._include_fields and exclude_fields or
-                self._exclude_fields and include_fields or
-                include_fields and exclude_fields):
-            raise errors.InvalidConfiguration(
-                "Cannot mix include fields and exclude fields in "
-                "namespace mapping for: '%s'" % (src_name,))
-        if dest_name is None:
-            dest_name = src_name
-        self._add_namespace(Namespace(
-            dest_name=dest_name, source_name=src_name,
-            include_fields=validate_include_fields(self._include_fields,
-                                                   include_fields),
-            exclude_fields=validate_exclude_fields(self._exclude_fields,
-                                                   exclude_fields)))
+    def _register_namespace_and_command(self, namespace):
+        """Add a Namespace and the corresponding command namespace."""
+        self._add_namespace(namespace)
         # Add the namespace for commands on this database
-        cmd_name = src_name.split('.', 1)[0] + '.$cmd'
-        dest_cmd_name = dest_name.split('.', 1)[0] + '.$cmd'
-        self._add_namespace(Namespace(
-            dest_name=dest_cmd_name, source_name=cmd_name))
+        cmd_name = namespace.source_name.split('.', 1)[0] + '.$cmd'
+        dest_cmd_name = namespace.dest_name.split('.', 1)[0] + '.$cmd'
+        self._add_namespace(Namespace(dest_name=dest_cmd_name,
+                                      source_name=cmd_name))
 
-    def _add_namespace(self, mapped_namespace):
+    def _add_namespace(self, namespace):
         """Add an included and possibly renamed Namespace."""
-        src_name = mapped_namespace.source_name
+        src_name = namespace.source_name
         if "*" in src_name:
             self._regex_map.append((namespace_to_regex(src_name),
-                                    mapped_namespace))
+                                    namespace))
         else:
-            self._add_plain_namespace(mapped_namespace)
+            self._add_plain_namespace(namespace)
 
-    def _add_plain_namespace(self, mapped_namespace):
+    def _add_plain_namespace(self, namespace):
         """Add an included and possibly renamed non-wildcard Namespace."""
-        src_name = mapped_namespace.source_name
-        target_name = mapped_namespace.dest_name
+        src_name = namespace.source_name
+        target_name = namespace.dest_name
         src_names = self._reverse_plain.setdefault(target_name, set())
         src_names.add(src_name)
         if len(src_names) > 1:
@@ -193,7 +179,7 @@ class NamespaceConfig(object):
                 "exists a mapping from '%s' to '%s'" %
                 (src_name, target_name, existing_src, target_name))
 
-        self._plain[src_name] = mapped_namespace
+        self._plain[src_name] = namespace
         src_db, _ = src_name.split(".", 1)
         target_db, _ = target_name.split(".", 1)
         self._plain_db.setdefault(src_db, set()).add(target_db)
@@ -215,19 +201,17 @@ class NamespaceConfig(object):
             return self._plain[plain_src_ns]
         except KeyError:
             # Search for the namespace in the wildcard namespaces.
-            for regex, mapped in self._regex_map:
+            for regex, namespace in self._regex_map:
                 new_name = match_replace_regex(regex, plain_src_ns,
-                                               mapped.dest_name)
+                                               namespace.dest_name)
                 if not new_name:
                     continue
                 # Save the new target Namespace in the plain namespaces so
                 # future lookups are fast.
-                new_mapped = Namespace(
-                    dest_name=new_name, source_name=plain_src_ns,
-                    include_fields=mapped.include_fields,
-                    exclude_fields=mapped.exclude_fields)
-                self._add_plain_namespace(new_mapped)
-                return new_mapped
+                new_namespace = namespace.with_options(
+                    dest_name=new_name, source_name=plain_src_ns)
+                self._add_plain_namespace(new_namespace)
+                return new_namespace
 
         # Save the not included namespace to the excluded namespaces so
         # that future lookups of the same namespace are fast.
@@ -238,9 +222,18 @@ class NamespaceConfig(object):
         """Given a plain source namespace, return the corresponding plain
         target namespace, or None if it is not included.
         """
-        mapped = self.lookup(plain_src_ns)
-        if mapped:
-            return mapped.dest_name
+        namespace = self.lookup(plain_src_ns)
+        if namespace:
+            return namespace.dest_name
+        return None
+
+    def gridfs_namespace(self, plain_src_ns):
+        """Given a plain source namespace, return the corresponding plain
+        target namespace if this namespace is a gridfs collection.
+        """
+        namespace = self.lookup(plain_src_ns)
+        if namespace and namespace.gridfs:
+            return namespace.dest_name
         return None
 
     def unmap_namespace(self, plain_target_ns):
@@ -257,10 +250,10 @@ class NamespaceConfig(object):
             for src_name in src_name_set:
                 return src_name
         # The target namespace could also exist in the wildcard namespaces
-        for _, mapped in self._regex_map:
+        for _, namespace in self._regex_map:
             original_name = match_replace_regex(
-                namespace_to_regex(mapped.dest_name), plain_target_ns,
-                mapped.source_name)
+                namespace_to_regex(namespace.dest_name), plain_target_ns,
+                namespace.source_name)
             if original_name:
                 return original_name
         return None
@@ -322,12 +315,24 @@ def wildcards_overlap(name1, name2):
     return False
 
 
-def validate_target_namespaces(user_mapping):
-    """Validate that no target namespaces overlap exactly with each other.
+def _validate_collection(name):
+    """Return true if this name looks like a MongoDB collection name."""
+    if name.find('.', 1, len(name) - 1) < 0:
+        raise errors.InvalidConfiguration(
+            "Invalid MongoDB collection name '%s'!" % (name,))
 
-    Also warns when wildcard namespaces have a chance of overlapping.
+
+def _validate_namespaces(namespaces):
+    """Validate wildcards and renaming in namespaces.
+
+    Target namespaces should have the same number of wildcards as the source.
+    No target namespaces overlap exactly with each other. Logs a warning
+    when wildcard namespaces have a chance of overlapping.
     """
-    for source, target in user_mapping.items():
+    for source, namespace in namespaces.items():
+        target = namespace.dest_name
+        _validate_collection(source)
+        _validate_collection(target)
         if source.count("*") > 1 or target.count("*") > 1:
             raise errors.InvalidConfiguration(
                 "The namespace mapping from '%s' to '%s' cannot contain more "
@@ -349,23 +354,123 @@ def validate_target_namespaces(user_mapping):
                 "source collection name must also appear in the target "
                 "collection name" % (source, target))
 
-    for namespace1, namespace2 in combinations(user_mapping.keys(), 2):
-        if wildcards_overlap(namespace1, namespace2):
-            LOG.warn('Namespaces "%s" and "%s" may match the '
-                     'same source namespace.', namespace1, namespace2)
-        target1 = user_mapping[namespace1]
-        target2 = user_mapping[namespace2]
+    for source1, source2 in combinations(namespaces.keys(), 2):
+        if wildcards_overlap(source1, source2):
+            LOG.warning('Namespaces "%s" and "%s" may match the '
+                        'same source namespace.', source1, source2)
+        target1 = namespaces[source1].dest_name
+        target2 = namespaces[source2].dest_name
         if target1 == target2:
             raise errors.InvalidConfiguration(
                 "Multiple namespaces cannot be combined into one target "
                 "namespace. Trying to map '%s' to '%s' but '%s' already "
                 "corresponds to '%s' in the target system." %
-                (namespace2, target2, namespace1, target1))
+                (source2, target2, source1, target1))
         if wildcards_overlap(target1, target2):
-            LOG.warn("Multiple namespaces cannot be combined into one target "
-                     "namespace. Mapping from '%s' to '%s' might overlap "
-                     "with mapping from '%s' to '%s'." %
-                     (namespace2, target2, namespace1, target1))
+            LOG.warning(
+                "Multiple namespaces cannot be combined into one target "
+                "namespace. Mapping from '%s' to '%s' might overlap "
+                "with mapping from '%s' to '%s'." %
+                (source2, target2, source1, target1))
+
+
+def _construct_namespace_options(namespace_set=None, ex_namespace_set=None,
+                                 gridfs_set=None, dest_mapping=None,
+                                 namespace_options=None,
+                                 include_fields=None, exclude_fields=None):
+    """Convert old style namespace configuration options."""
+    namespace_set = set(namespace_set or [])
+    ex_namespace_set = set(ex_namespace_set or [])
+    gridfs_set = set(gridfs_set or [])
+    dest_mapping = dest_mapping or {}
+    namespace_options = namespace_options or {}
+    include_fields = set(include_fields or [])
+    exclude_fields = set(exclude_fields or [])
+    namespaces = {}
+
+    for source_name, options_or_str in namespace_options.items():
+        if isinstance(options_or_str, dict):
+            namespace_set.add(source_name)
+            if options_or_str.get('gridfs'):
+                gridfs_set.add(source_name)
+            namespaces[source_name] = Namespace(
+                dest_name=options_or_str.get('rename'),
+                include_fields=options_or_str.get('includeFields'),
+                exclude_fields=options_or_str.get('excludeFields'),
+                gridfs=options_or_str.get('gridfs', False))
+        elif compat.is_string(options_or_str):
+            namespace_set.add(source_name)
+            namespaces[source_name] = Namespace(dest_name=options_or_str)
+        elif options_or_str:
+            namespace_set.add(source_name)
+        else:
+            ex_namespace_set.add(source_name)
+
+    # Add namespaces that are renamed but not in namespace_options
+    for source_name, target_name in dest_mapping.items():
+        namespaces[source_name] = namespaces.get(
+            source_name, Namespace()).with_options(dest_name=target_name)
+
+    # Add namespaces that are included but not in namespace_options
+    for included_name in namespace_set:
+        if included_name not in namespaces:
+            namespaces[included_name] = Namespace()
+
+    # Add namespaces that are excluded but not in namespace_options
+    for gridfs_name in gridfs_set:
+        namespaces[gridfs_name] = namespaces.get(
+            gridfs_name, Namespace()).with_options(gridfs=True)
+
+    # Add source, destination name, and globally included and excluded fields
+    for included_name in namespaces:
+        namespace = namespaces[included_name]
+        namespace = namespace.with_options(
+            source_name=included_name,
+            include_fields=validate_include_fields(include_fields,
+                                                   namespace.include_fields),
+            exclude_fields=validate_exclude_fields(exclude_fields,
+                                                   namespace.exclude_fields))
+        # The default destination name is the same as the source.
+        if not namespace.dest_name:
+            namespace = namespace.with_options(dest_name=included_name)
+        namespaces[included_name] = namespace
+
+    return ex_namespace_set, namespaces
+
+
+def validate_namespace_options(namespace_set=None, ex_namespace_set=None,
+                               gridfs_set=None, dest_mapping=None,
+                               namespace_options=None,
+                               include_fields=None, exclude_fields=None):
+    ex_namespace_set, namespaces = _construct_namespace_options(
+        namespace_set=namespace_set,
+        ex_namespace_set=ex_namespace_set,
+        gridfs_set=gridfs_set,
+        dest_mapping=dest_mapping,
+        namespace_options=namespace_options,
+        include_fields=include_fields,
+        exclude_fields=exclude_fields)
+
+    for excluded_name in ex_namespace_set:
+        _validate_collection(excluded_name)
+        if excluded_name in namespaces:
+            raise errors.InvalidConfiguration(
+                "Cannot include namespace '%s', it is already excluded." %
+                (excluded_name,))
+
+    for namespace in namespaces.values():
+        if namespace.include_fields and namespace.exclude_fields:
+            raise errors.InvalidConfiguration(
+                "Cannot mix include fields and exclude fields in "
+                "namespace mapping for: '%s'" % (namespace.source_name,))
+
+        if namespace.gridfs and namespace.dest_name != namespace.source_name:
+            raise errors.InvalidConfiguration(
+                "GridFS namespaces cannot be renamed: '%s'" % (
+                    namespace.source_name,))
+
+    _validate_namespaces(namespaces)
+    return ex_namespace_set, namespaces.values()
 
 
 def match_replace_regex(regex, src_namespace, dest_namespace):
@@ -384,14 +489,12 @@ def wildcard_in_db(namespace):
 
 def namespace_to_regex(namespace):
     """Create a RegexObject from a wildcard namespace."""
-    if wildcard_in_db(namespace):
-        # A database name cannot contain a '.' character
-        wildcard_group = '([^.]*)'
-    else:
-        wildcard_group = '(.*)'
-    return re.compile(r'\A' +
-                      re.escape(namespace).replace('\*', wildcard_group) +
-                      r'\Z')
+    db_name, coll_name = namespace.split('.', 1)
+    # A database name cannot contain a '.' character
+    db_regex = re.escape(db_name).replace('\*', '([^.]*)')
+    # But a collection name can.
+    coll_regex = re.escape(coll_name).replace('\*', '(.*)')
+    return re.compile(r'\A' + db_regex + r'\.' + coll_regex + r'\Z')
 
 
 def validate_include_fields(include_fields, namespace_fields=None):

--- a/tests/test_command_replication.py
+++ b/tests/test_command_replication.py
@@ -112,7 +112,7 @@ class TestCommandReplication(unittest.TestCase):
         }
 
         helper = CommandHelper(NamespaceConfig(
-            namespace_set=list(mapping) + ['a.z'], user_mapping=mapping))
+            namespace_set=list(mapping) + ['a.z'], namespace_options=mapping))
 
         self.assertEqual(set(helper.map_db('a')), set(['a', 'b', 'c']))
         self.assertEqual(helper.map_db('d'), [])

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -253,17 +253,6 @@ class TestConfig(unittest.TestCase):
         }
         self.assertRaises(errors.InvalidConfiguration, self.load_options, args)
 
-        # ns_set and ex_ns_set should not exist both
-        args = {
-            "-n": "a.x,b.y",
-            "-x": "c.z"
-        }
-        self.assertRaises(errors.InvalidConfiguration, self.load_options, args)
-        d = {
-            'namespaces': {'include': ['a.x', 'b.y'], 'exclude': ['c.z']}
-        }
-        self.assertRaises(errors.InvalidConfiguration, self.load_json, d)
-
         # validate ns_set format
         args = {
             "-n": "a*.x*"
@@ -271,16 +260,6 @@ class TestConfig(unittest.TestCase):
         self.assertRaises(errors.InvalidConfiguration, self.load_options, args)
         d = {
             'namespaces': {'include': ['a*.x*']}
-        }
-        self.assertRaises(errors.InvalidConfiguration, self.load_json, d)
-
-        # validate ex_ns_set format
-        args = {
-            "-x": "a*.x*"
-        }
-        self.assertRaises(errors.InvalidConfiguration, self.load_options, args)
-        d = {
-            'namespaces': {'exclude': ['a*.x*']}
         }
         self.assertRaises(errors.InvalidConfiguration, self.load_json, d)
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -282,6 +282,19 @@ class TestConfig(unittest.TestCase):
         }
         self.assertRaises(errors.InvalidConfiguration, self.load_json, d)
 
+    def test_validate_mixed_namespace_format(self):
+        # It is invalid to combine new and old namespace formats
+        mix_namespaces = [
+            {'mapping': {'old.format': 'old.format2'}, 'new.format': True},
+            {'gridfs': ['old.format'], 'new.format': True},
+            {'include': ['old.format'], 'new.format': True},
+            {'exclude': ['old.format'], 'new.format': True},
+        ]
+        for namespaces in mix_namespaces:
+            with self.assertRaises(errors.InvalidConfiguration):
+                self.load_json({'namespaces': namespaces})
+
+
     def test_doc_managers_from_args(self):
         # Test basic docmanager construction from args
         args = {

--- a/tests/test_mongo_connector.py
+++ b/tests/test_mongo_connector.py
@@ -56,7 +56,6 @@ class TestMongoConnector(unittest.TestCase):
         """
         conn = Connector(
             mongo_address=self.repl_set.uri,
-            ns_set=['test.test'],
             **connector_opts
         )
         conn.start()
@@ -81,7 +80,6 @@ class TestMongoConnector(unittest.TestCase):
         conn = Connector(
             mongo_address=self.repl_set.uri,
             oplog_checkpoint="temp_oplog.timestamp",
-            ns_set=['test.test'],
             **connector_opts
         )
 
@@ -118,7 +116,6 @@ class TestMongoConnector(unittest.TestCase):
         conn = Connector(
             mongo_address=self.repl_set.uri,
             oplog_checkpoint=None,
-            ns_set=['test.test'],
             **connector_opts
         )
 

--- a/tests/test_mongo_doc_manager.py
+++ b/tests/test_mongo_doc_manager.py
@@ -232,7 +232,7 @@ class TestMongoDocManager(MongoTestCase):
         # renaming a database.
         namespace_config = NamespaceConfig(
             namespace_set=['test.test', 'test.test2', 'test.drop'],
-            user_mapping={
+            namespace_options={
              'test.test': 'test.othertest',
              'test.drop': 'dropped.collection'
             })

--- a/tests/test_namespace_config.py
+++ b/tests/test_namespace_config.py
@@ -169,6 +169,62 @@ class TestDNamespaceConfig(unittest.TestCase):
         with self.assertRaises(errors.InvalidConfiguration):
             NamespaceConfig(user_mapping={"db.*": "new_db_*.col"})
 
+    def test_fields_validation(self):
+        """Test including/excluding fields per namespace."""
+        # Cannot include and exclude fields in the same namespace
+        with self.assertRaises(errors.InvalidConfiguration):
+            NamespaceConfig(user_mapping={
+                "db.col": {"fields": ["a"], "excludeFields": ["b"]}})
+
+        # Cannot include fields globally and then exclude fields
+        with self.assertRaises(errors.InvalidConfiguration):
+            NamespaceConfig(include_fields=["a"], user_mapping={
+                "db.col": {"excludeFields": ["b"]}})
+
+        # Cannot exclude fields globally and then include fields
+        with self.assertRaises(errors.InvalidConfiguration):
+            NamespaceConfig(exclude_fields=["b"], user_mapping={
+                "db.col": {"fields": ["a"]}})
+
+    def test_projection_include_wildcard(self):
+        """Test include_fields on a wildcard namespace."""
+        equivalent_namespace_configs = (
+            NamespaceConfig(include_fields=["foo", "nested.field"],
+                            ex_namespace_set=["ignored.name"]),
+            NamespaceConfig(include_fields=["foo", "nested.field"],
+                            namespace_set=["db.foo"]),
+            NamespaceConfig(include_fields=["foo", "nested.field"],
+                            namespace_set=["db.*"]),
+            NamespaceConfig(user_mapping={
+                "db.*": {"fields": ["foo", "nested.field"]}}),
+            NamespaceConfig(user_mapping={
+                "db.foo": {"fields": ["foo", "nested.field"]}}),
+            NamespaceConfig(include_fields=["foo", "nested.field"],
+                            user_mapping={
+                                "db.*": {"fields": ["foo", "nested.field"]}})
+        )
+        for namespace_config in equivalent_namespace_configs:
+            self.assertEqual(namespace_config.projection("db.foo"),
+                             {"_id": 1, "foo": 1, "nested.field": 1})
+            self.assertIsNone(namespace_config.projection("ignored.name"))
+
+    def test_projection_exclude_wildcard(self):
+        """Test exclude_fields on a wildcard namespace."""
+        equivalent_namespace_configs = (
+            NamespaceConfig(exclude_fields=["_id", "foo", "nested.field"],
+                            namespace_set=["db.*"]),
+            NamespaceConfig(user_mapping={
+                "db.*": {"excludeFields": ["_id", "foo", "nested.field"]}}),
+            NamespaceConfig(
+                exclude_fields=["foo", "nested.field"],
+                user_mapping={"db.*": {
+                    "excludeFields": ["_id", "foo", "nested.field"]}})
+        )
+        for namespace_config in equivalent_namespace_configs:
+            self.assertEqual(namespace_config.projection("db.foo"),
+                             {"foo": 0, "nested.field": 0})
+            self.assertIsNone(namespace_config.projection("ignored.name"))
+
     def test_match_replace_regex(self):
         """Test regex matching and replacing."""
         regex = re.compile(r"\Adb_([^.]*).foo\Z")

--- a/tests/test_namespace_config.py
+++ b/tests/test_namespace_config.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
+import os
 import re
 
 from tests import unittest
@@ -21,7 +23,11 @@ from mongo_connector.namespace_config import (
 from mongo_connector import errors
 
 
-class TestDNamespaceConfig(unittest.TestCase):
+CONFIG_PATH = os.path.join(os.path.dirname(os.path.dirname(
+    os.path.realpath(__file__))), "config.json")
+
+
+class TestNamespaceConfig(unittest.TestCase):
     """Test the NamespaceConfig class"""
 
     def test_default(self):
@@ -32,6 +38,12 @@ class TestDNamespaceConfig(unittest.TestCase):
         self.assertEqual(namespace_config.map_db("db1"), ["db1"])
         self.assertEqual(namespace_config.map_namespace("db1.col1"),
                          "db1.col1")
+
+    def test_config(self):
+        """Test that the namespace option in the example config is valid."""
+        with open(CONFIG_PATH) as filep:
+            namespaces = json.load(filep)['__namespaces']
+            NamespaceConfig(namespace_options=namespaces)
 
     def test_include_plain(self):
         """Test including namespaces without wildcards"""
@@ -54,13 +66,15 @@ class TestDNamespaceConfig(unittest.TestCase):
         """Test including namespaces with wildcards"""
         equivalent_namespace_configs = (
             NamespaceConfig(namespace_set=["db1.*"]),
-            NamespaceConfig(user_mapping={"db1.*": {}}),
-            NamespaceConfig(user_mapping={"db1.*": {"rename": "db1.*"}}))
+            NamespaceConfig(namespace_options={"db1.*": {}}),
+            NamespaceConfig(namespace_options={"db1.*": True}),
+            NamespaceConfig(namespace_options={"db1.*": {"rename": "db1.*"}})
+        )
         for namespace_config in equivalent_namespace_configs:
             self.assertEqual(namespace_config.unmap_namespace("db1.col1"),
                              "db1.col1")
-            self.assertEqual(namespace_config.unmap_namespace("db1.col1"),
-                             "db1.col1")
+            self.assertEqual(namespace_config.unmap_namespace("db1.col2"),
+                             "db1.col2")
             self.assertEqual(namespace_config.lookup("db1.col1"),
                              Namespace(dest_name="db1.col1",
                                        source_name="db1.col1"))
@@ -71,7 +85,7 @@ class TestDNamespaceConfig(unittest.TestCase):
 
     def test_map_db_wildcard(self):
         """Test a crazy namespace renaming scheme with wildcards."""
-        namespace_config = NamespaceConfig(user_mapping={
+        namespace_config = NamespaceConfig(namespace_options={
             "db.1_*": "db1.new_*",
             "db.2_*": "db2.new_*",
             "db.3": "new_db.3"})
@@ -106,6 +120,30 @@ class TestDNamespaceConfig(unittest.TestCase):
             "db&_foo.$_^_#_!_[_]_")
         self.assertIsNone(namespace_config.map_namespace("db&.foo"))
 
+    def test_gridfs(self):
+        """Test the gridfs property is set correctly."""
+        equivalent_namespace_configs = (
+            NamespaceConfig(gridfs_set=["db1.*"]),
+            NamespaceConfig(namespace_options={"db1.*": {"gridfs": True}})
+        )
+        for namespace_config in equivalent_namespace_configs:
+            self.assertEqual(namespace_config.unmap_namespace("db1.col1"),
+                             "db1.col1")
+            self.assertEqual(namespace_config.unmap_namespace("db1.col2"),
+                             "db1.col2")
+            self.assertEqual(namespace_config.lookup("db1.col1"),
+                             Namespace(dest_name="db1.col1",
+                                       source_name="db1.col1",
+                                       gridfs=True))
+            self.assertListEqual(namespace_config.map_db("db1"), ["db1"])
+            self.assertEqual(namespace_config.map_namespace("db1.col1"),
+                             "db1.col1")
+            self.assertIsNone(namespace_config.map_namespace("db2.col4"))
+            self.assertTrue(namespace_config.lookup("db1.col1").gridfs)
+            self.assertEqual(namespace_config.gridfs_namespace("db1.col1"),
+                             "db1.col1")
+            self.assertIsNone(namespace_config.gridfs_namespace("not.gridfs"))
+
     def test_exclude_plain(self):
         """Test excluding namespaces without wildcards"""
         namespace_config = NamespaceConfig(ex_namespace_set=["ex.clude"])
@@ -117,17 +155,60 @@ class TestDNamespaceConfig(unittest.TestCase):
 
     def test_exclude_wildcard(self):
         """Test excluding namespaces with wildcards"""
-        namespace_config = NamespaceConfig(ex_namespace_set=["ex.*"])
-        self.assertEqual(namespace_config.unmap_namespace("db.col"), "db.col")
-        self.assertEqual(namespace_config.unmap_namespace("ex.clude"),
-                         "ex.clude")
-        self.assertEqual(namespace_config.map_namespace("db.col"), "db.col")
-        self.assertIsNone(namespace_config.map_namespace("ex.clude"))
-        self.assertIsNone(namespace_config.map_namespace("ex.clude2"))
+        equivalent_namespace_configs_for_tests = (
+            NamespaceConfig(ex_namespace_set=["ex.*", "ex2.*"]),
+            NamespaceConfig(namespace_options={"ex.*": False, "ex2.*": False}),
+            # Multiple wildcards in exclude namespace
+            NamespaceConfig(ex_namespace_set=["e*.*"]),
+        )
+        for namespace_config in equivalent_namespace_configs_for_tests:
+            self.assertEqual(namespace_config.unmap_namespace("db.col"),
+                             "db.col")
+            self.assertEqual(namespace_config.unmap_namespace("ex.clude"),
+                             "ex.clude")
+            self.assertEqual(namespace_config.map_namespace("db.col"),
+                             "db.col")
+            self.assertIsNone(namespace_config.map_namespace("ex.clude"))
+            self.assertIsNone(namespace_config.map_namespace("ex2.clude"))
+
+    def test_include_and_exclude(self):
+        """Test including and excluding namespaces at the same time."""
+        equivalent_namespace_configs_for_tests = (
+            NamespaceConfig(ex_namespace_set=["ex.*"],
+                            namespace_set=["ex.cluded_still", "in.cluded"]),
+            NamespaceConfig(namespace_options={
+                "ex.*": False, "ex.cluded_still": True, "in.cluded": True}),
+            NamespaceConfig(ex_namespace_set=["ex.cluded", "ex.cluded_still"],
+                            namespace_set=["ex.*", "in.cluded"])
+        )
+        for namespace_config in equivalent_namespace_configs_for_tests:
+            self.assertIsNone(namespace_config.map_namespace("ex.cluded"))
+            # Excluded namespaces take precedence over included ones.
+            self.assertIsNone(
+                namespace_config.map_namespace("ex.cluded_still"))
+            # Namespaces that are not explicitly included are ignored.
+            self.assertIsNone(
+                namespace_config.map_namespace("also.not.included"))
+            self.assertEqual(
+                namespace_config.map_namespace("in.cluded"), "in.cluded")
+
+    def test_include_and_exclude_validation(self):
+        """Test including and excluding the same namespaces is an error."""
+        equivalent_namespace_config_kwargs = (
+            dict(ex_namespace_set=["ex.cluded"],
+                 namespace_set=["in.cluded", "ex.cluded"]),
+            dict(namespace_set=["ex.cluded"], namespace_options={
+                "ex.cluded": False, "in.cluded": True}),
+            dict(ex_namespace_set=["ex.cluded", "in.cluded"],
+                 namespace_options={"in.cluded": True})
+        )
+        for kwargs in equivalent_namespace_config_kwargs:
+            with self.assertRaises(errors.InvalidConfiguration):
+                NamespaceConfig(**kwargs)
 
     def test_unmap_namespace_wildcard(self):
         """Test un-mapping a namespace that was never explicitly mapped."""
-        namespace_config = NamespaceConfig(user_mapping={
+        namespace_config = NamespaceConfig(namespace_options={
             "db2.*": "db2.f*",
             "db_*.foo": "db_new_*.foo",
         })
@@ -135,22 +216,70 @@ class TestDNamespaceConfig(unittest.TestCase):
         self.assertEqual(namespace_config.unmap_namespace("db_new_123.foo"),
                          "db_123.foo")
 
+    def test_override_namespace_options(self):
+        """Test gridfs_set and dest_mapping arguments override
+        namespace_options.
+        """
+        namespace_config = NamespaceConfig(
+            namespace_set=["override.me", "override.me2"],
+            gridfs_set=["override.me3"],
+            dest_mapping={
+                "override.me": "overridden.1",
+                "override.me2": "overridden.2"
+            },
+            namespace_options={
+                "override.me": {
+                    "rename": "override.me",
+                    "includeFields": ["_id", "dont_remove"]
+                },
+                "override.me2": "override.me2",
+                "override.me3": {'gridfs': False}
+
+            }
+        )
+        overridden = namespace_config.lookup("override.me")
+        self.assertEqual(overridden.dest_name, "overridden.1")
+        self.assertEqual(overridden.include_fields,
+                         set(["_id", "dont_remove"]))
+        overridden = namespace_config.lookup("override.me2")
+        self.assertEqual(overridden.dest_name, "overridden.2")
+        self.assertFalse(overridden.include_fields)
+        self.assertTrue(namespace_config.gridfs_namespace("override.me3"))
+
+    def test_invalid_collection_name_validation(self):
+        """Test that invalid collection names raise InvalidConfiguration."""
+        equivalent_namespace_config_kwargs = (
+            dict(namespace_options={"invalid_db": "newinvalid_db"}),
+            dict(namespace_set=["invalid_db."]),
+            dict(ex_namespace_set=[".invalid_db"]),
+            dict(gridfs_set=[".invalid_db"])
+        )
+        for kwargs in equivalent_namespace_config_kwargs:
+            with self.assertRaises(errors.InvalidConfiguration):
+                NamespaceConfig(**kwargs)
+
+    def test_gridfs_rename_invalid(self):
+        """Test that renaming a GridFS collection is invalid."""
+        with self.assertRaises(errors.InvalidConfiguration):
+            NamespaceConfig(namespace_options={
+                "gridfs.*": {'rename': 'new_gridfs.*', 'gridfs': True}})
+
     def test_rename_validation(self):
         """Test namespace renaming validation."""
         # Multiple collections cannot be merged into the same target namespace
         with self.assertRaises(errors.InvalidConfiguration):
-            NamespaceConfig(user_mapping={
+            NamespaceConfig(namespace_options={
                 "db1.col1": "newdb.newcol",
                 "db2.col1": "newdb.newcol"})
 
         # Multiple collections cannot be merged into the same target namespace
         with self.assertRaises(errors.InvalidConfiguration):
-            NamespaceConfig(user_mapping={
+            NamespaceConfig(namespace_options={
                 "db*.col1": "newdb.newcol*",
                 "db*.col2": "newdb.newcol*"})
 
         # Multiple collections cannot be merged into the same target namespace
-        namespace_config = NamespaceConfig(user_mapping={
+        namespace_config = NamespaceConfig(namespace_options={
             "*.coll": "*.new_coll",
             "db.*": "new_db.*"})
         namespace_config.map_namespace("new_db.coll")
@@ -162,29 +291,29 @@ class TestDNamespaceConfig(unittest.TestCase):
         # For the sake of map_db, wildcards cannot be moved from database name
         # to collection name.
         with self.assertRaises(errors.InvalidConfiguration):
-            NamespaceConfig(user_mapping={"db*.col": "new_db.col_*"})
+            NamespaceConfig(namespace_options={"db*.col": "new_db.col_*"})
 
         # For the sake of map_db, wildcards cannot be moved from collection
         # name to database name.
         with self.assertRaises(errors.InvalidConfiguration):
-            NamespaceConfig(user_mapping={"db.*": "new_db_*.col"})
+            NamespaceConfig(namespace_options={"db.*": "new_db_*.col"})
 
     def test_fields_validation(self):
         """Test including/excluding fields per namespace."""
         # Cannot include and exclude fields in the same namespace
         with self.assertRaises(errors.InvalidConfiguration):
-            NamespaceConfig(user_mapping={
-                "db.col": {"fields": ["a"], "excludeFields": ["b"]}})
+            NamespaceConfig(namespace_options={
+                "db.col": {"includeFields": ["a"], "excludeFields": ["b"]}})
 
         # Cannot include fields globally and then exclude fields
         with self.assertRaises(errors.InvalidConfiguration):
-            NamespaceConfig(include_fields=["a"], user_mapping={
+            NamespaceConfig(include_fields=["a"], namespace_options={
                 "db.col": {"excludeFields": ["b"]}})
 
         # Cannot exclude fields globally and then include fields
         with self.assertRaises(errors.InvalidConfiguration):
-            NamespaceConfig(exclude_fields=["b"], user_mapping={
-                "db.col": {"fields": ["a"]}})
+            NamespaceConfig(exclude_fields=["b"], namespace_options={
+                "db.col": {"includeFields": ["a"]}})
 
     def test_projection_include_wildcard(self):
         """Test include_fields on a wildcard namespace."""
@@ -195,13 +324,15 @@ class TestDNamespaceConfig(unittest.TestCase):
                             namespace_set=["db.foo"]),
             NamespaceConfig(include_fields=["foo", "nested.field"],
                             namespace_set=["db.*"]),
-            NamespaceConfig(user_mapping={
-                "db.*": {"fields": ["foo", "nested.field"]}}),
-            NamespaceConfig(user_mapping={
-                "db.foo": {"fields": ["foo", "nested.field"]}}),
+            NamespaceConfig(namespace_options={
+                "db.*": {"includeFields": ["foo", "nested.field"]}}),
+            NamespaceConfig(namespace_options={
+                "db.foo": {"includeFields": ["foo", "nested.field"]}}),
             NamespaceConfig(include_fields=["foo", "nested.field"],
-                            user_mapping={
-                                "db.*": {"fields": ["foo", "nested.field"]}})
+                            namespace_options={
+                                "db.*": {
+                                    "includeFields": ["foo", "nested.field"]
+                                }})
         )
         for namespace_config in equivalent_namespace_configs:
             self.assertEqual(namespace_config.projection("db.foo"),
@@ -213,11 +344,11 @@ class TestDNamespaceConfig(unittest.TestCase):
         equivalent_namespace_configs = (
             NamespaceConfig(exclude_fields=["_id", "foo", "nested.field"],
                             namespace_set=["db.*"]),
-            NamespaceConfig(user_mapping={
+            NamespaceConfig(namespace_options={
                 "db.*": {"excludeFields": ["_id", "foo", "nested.field"]}}),
             NamespaceConfig(
                 exclude_fields=["foo", "nested.field"],
-                user_mapping={"db.*": {
+                namespace_options={"db.*": {
                     "excludeFields": ["_id", "foo", "nested.field"]}})
         )
         for namespace_config in equivalent_namespace_configs:

--- a/tests/test_oplog_manager_wildcard.py
+++ b/tests/test_oplog_manager_wildcard.py
@@ -48,7 +48,7 @@ class TestOplogManager(unittest.TestCase):
     def reset_opman(self, include_ns=None, exclude_ns=None, dest_mapping=None):
         self.namespace_config = NamespaceConfig(namespace_set=include_ns,
                                                 ex_namespace_set=exclude_ns,
-                                                user_mapping=dest_mapping)
+                                                namespace_options=dest_mapping)
         self.opman = OplogThread(
             primary_client=self.primary_conn,
             doc_managers=(DocManager(),),

--- a/tests/test_synchronizer.py
+++ b/tests/test_synchronizer.py
@@ -22,6 +22,7 @@ import time
 sys.path[0:0] = [""]
 
 from mongo_connector.connector import Connector
+from mongo_connector.namespace_config import NamespaceConfig
 from mongo_connector.test_utils import (assert_soon,
                                         connector_opts,
                                         ReplicaSetSingle)
@@ -138,7 +139,8 @@ class TestSynchronizer(unittest.TestCase):
 
         # ensure update works when fields are given
         opthread = self.connector.shard_set[0]
-        opthread.fields = ['a', 'b', 'c']
+        opthread.namespace_config = NamespaceConfig(
+            include_fields=['a', 'b', 'c'])
         try:
             doc = update_and_retrieve({"$set": {"d": 10}})
             self.assertEqual(self.conn.test.test.find_one(doc['_id'])['d'], 10)


### PR DESCRIPTION
This change implements https://github.com/mongodb-labs/mongo-connector/issues/497 and enhances the refactoring of https://github.com/mongodb-labs/mongo-connector/pulls/601 by unifying all the namespace options into a new format.

In addition, `gridfs` namespaces now have support for wildcard (`*`) globbing. The new format for the namespaces configuration option is shown below and in `config.json`. 

```json
{
    "__namespaces": {
        "excluded.collection": false,
        "excluded_wildcard.*": false,
        "*.exclude_collection_from_every_database": false,
        "included.collection1": true,
        "included.collection2": {},
        "included.collection4": {
            "includeFields": ["included_field", "included.nested.field"]
        },
        "included.collection5": {
            "rename": "included.new_collection5_name",
            "includeFields": ["included_field", "included.nested.field"]
        },
        "included.collection6": {
            "excludeFields": ["excluded_field", "excluded.nested.field"]
        },
        "included.collection7": {
            "rename": "included.new_collection7_name",
            "excludeFields": ["excluded_field", "excluded.nested.field"]
        },
        "included_wildcard1.*": true,
        "included_wildcard2.*": true,
        "renamed.collection1": "something.else1",
        "renamed.collection2": {
            "rename": "something.else2"
        },
        "renamed_wildcard.*": {
            "rename": "new_name.*"
        },
        "gridfs.collection": {
            "gridfs": true
        },
        "gridfs_wildcard.*": {
            "gridfs": true
        }
    }
}
```

Note: The old style configuration options are still valid so this change is backward compatible BUT to make use of the new `includeFields` and `excludeFields` parameters you will need to update config files to the new format.
