### PR TITLE
Ignore KeyError for since the oplog can contain duplicates for Mongo

### DIFF
--- a/mongo_connector/doc_managers/doc_manager_base.py
+++ b/mongo_connector/doc_managers/doc_manager_base.py
@@ -76,8 +76,8 @@ class DocManagerBase(object):
                 else:
                     doc.pop(to_unset)
             except KeyError:
-                # Ignore KeyError since the oplog can contain $unset on fields
-                # that does not exist
+                # Ignore KeyError since a MongoDB 2.4 oplog can contain $unset
+                # on fields that do not exist.
                 pass
 
         # wholesale document replacement


### PR DESCRIPTION
MongoDB 2.4 can have duplicate `$unset` for a field in the oplog which causes mongo-connector to throw a `KeyError`. This fixes the problem by ignoring the KeyError for `$unset`. 

For more info, see #621 