### PR TITLE
Bug fix: only use listDatabases when necessary

### DIFF
--- a/mongo_connector/namespace_config.py
+++ b/mongo_connector/namespace_config.py
@@ -289,6 +289,20 @@ class NamespaceConfig(object):
             return dict((field, include) for field in fields)
         return None
 
+    def get_included_databases(self):
+        """Return the databases we want to include, or empty list for all.
+        """
+        databases = set()
+        databases.update(self._plain_db.keys())
+
+        for _, namespace in self._regex_map:
+            database_name, _ = namespace.source_name.split('.', 1)
+            if '*' in database_name:
+                return []
+            databases.add(database_name)
+
+        return list(databases)
+
 
 def _character_matches(name1, name2):
     """Yield the number of characters that match the beginning of each string.

--- a/mongo_connector/oplog_manager.py
+++ b/mongo_connector/oplog_manager.py
@@ -503,7 +503,11 @@ class OplogThread(threading.Thread):
         def get_all_ns():
             ns_set = []
             gridfs_ns_set = []
-            db_list = retry_until_ok(self.primary_client.database_names)
+            db_list = self.namespace_config.get_included_databases()
+            if not db_list:
+                # Only use listDatabases when the configured databases are not
+                # explicit.
+                db_list = retry_until_ok(self.primary_client.database_names)
             for database in db_list:
                 if database == "config" or database == "local":
                     continue

--- a/tests/test_namespace_config.py
+++ b/tests/test_namespace_config.py
@@ -356,6 +356,21 @@ class TestNamespaceConfig(unittest.TestCase):
                              {"foo": 0, "nested.field": 0})
             self.assertIsNone(namespace_config.projection("ignored.name"))
 
+    def test_get_included_databases(self):
+        """Test get_included_databases."""
+        nc_requires_list_databases = (
+            NamespaceConfig(),
+            NamespaceConfig(namespace_options={"db.c": False}),
+            NamespaceConfig(namespace_options={"db*.c": True}),
+        )
+        for namespace_config in nc_requires_list_databases:
+            self.assertEqual(namespace_config.get_included_databases(), [])
+
+        namespace_config = NamespaceConfig(namespace_options={"db.c": True})
+        self.assertEqual(namespace_config.get_included_databases(), ["db"])
+        namespace_config = NamespaceConfig(namespace_options={"db.*": True})
+        self.assertEqual(namespace_config.get_included_databases(), ["db"])
+
     def test_match_replace_regex(self):
         """Test regex matching and replacing."""
         regex = re.compile(r"\Adb_([^.]*).foo\Z")


### PR DESCRIPTION
This changes mongo-connector to only use listDatabases when the user does not provide explicit databases in the configuration. Previously, we would always run listDatabases. This allows mongo-connector to be used with a user that does not have the `listDatabases` privilege.

Fixes #626.