### PR TITLE
Skip test that fails often on MongoDB < 3.0 because of SERVER-13212

### DIFF
--- a/tests/version.py
+++ b/tests/version.py
@@ -1,0 +1,88 @@
+# Copyright 2017 MongoDB, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Some tools for working with MongoDB server versions."""
+
+
+class Version(tuple):
+
+    def __new__(cls, *version):
+        padded_version = cls._padded(version, 4)
+        return super(Version, cls).__new__(cls, tuple(padded_version))
+
+    @classmethod
+    def _padded(cls, iter, length, padding=0):
+        l = list(iter)
+        if len(l) < length:
+            for _ in range(length - len(l)):
+                l.append(padding)
+        return l
+
+    @classmethod
+    def from_string(cls, version_string):
+        mod = 0
+        bump_patch_level = False
+        if version_string.endswith("+"):
+            version_string = version_string[0:-1]
+            mod = 1
+        elif version_string.endswith("-pre-"):
+            version_string = version_string[0:-5]
+            mod = -1
+        elif version_string.endswith("-"):
+            version_string = version_string[0:-1]
+            mod = -1
+        # Deal with '-rcX' substrings
+        if '-rc' in version_string:
+            version_string = version_string[0:version_string.find('-rc')]
+            mod = -1
+        # Deal with git describe generated substrings
+        elif '-' in version_string:
+            version_string = version_string[0:version_string.find('-')]
+            mod = -1
+            bump_patch_level = True
+
+
+        version = [int(part) for part in version_string.split(".")]
+        version = cls._padded(version, 3)
+        # Make from_string and from_version_array agree. For example:
+        # MongoDB Enterprise > db.runCommand('buildInfo').versionArray
+        # [ 3, 2, 1, -100 ]
+        # MongoDB Enterprise > db.runCommand('buildInfo').version
+        # 3.2.0-97-g1ef94fe
+        if bump_patch_level:
+            version[-1] += 1
+        version.append(mod)
+
+        return Version(*version)
+
+    @classmethod
+    def from_version_array(cls, version_array):
+        version = list(version_array)
+        if version[-1] < 0:
+            version[-1] = -1
+        version = cls._padded(version, 3)
+        return Version(*version)
+
+    @classmethod
+    def from_client(cls, client):
+        info = client.server_info()
+        if 'versionArray' in info:
+            return cls.from_version_array(info['versionArray'])
+        return cls.from_string(info['version'])
+
+    def at_least(self, *other_version):
+        return self >= Version(*other_version)
+
+    def __str__(self):
+        return ".".join(map(str, self))


### PR DESCRIPTION
In MongoDB<3.0.7 there's a race condition with listDatabases and dropDatabase that can cause dropped databases to be recreated. See https://jira.mongodb.org/browse/SERVER-13212 and related tickets.

Example Mongod log:
```
 2017-02-16T11:59:49.680-0800 [conn9] run command new2.$cmd { dropDatabase: 1 }
 2017-02-16T11:59:49.681-0800 [conn9] dropDatabase new2 starting
 2017-02-16T11:59:49.681-0800 [conn8] run command admin.$cmd { listDatabases: 1 }
 2017-02-16T11:59:49.681-0800 [conn8] command: { listDatabases: 1 }
 2017-02-16T11:59:49.681-0800 [conn8] checking size file /var/folders/lm/b1r2f8p503xg40r6x2rqv7fr0000gp/T/mongo-eqCGuU/__mongo_connector.ns
 2017-02-16T11:59:49.687-0800 [conn9] dropDatabase new2
 2017-02-16T11:59:49.687-0800 [conn9] _groupCommit
 2017-02-16T11:59:49.687-0800 [conn9] journal REMAPPRIVATEVIEW
 2017-02-16T11:59:49.687-0800 [conn9] journal REMAPPRIVATEVIEW done startedAt: 5 n:3 0ms
 2017-02-16T11:59:49.687-0800 [conn9] groupCommit end
 2017-02-16T11:59:49.705-0800 [conn9] removeJournalFiles
 2017-02-16T11:59:49.706-0800 [conn9] removeJournalFiles end
 2017-02-16T11:59:49.706-0800 [conn9] mmf close /var/folders/lm/b1r2f8p503xg40r6x2rqv7fr0000gp/T/mongo-eqCGuU/new2.0
 2017-02-16T11:59:49.706-0800 [conn9] _groupCommit
 2017-02-16T11:59:49.706-0800 [conn9] journal REMAPPRIVATEVIEW
 2017-02-16T11:59:49.706-0800 [conn9] journal REMAPPRIVATEVIEW done startedAt: 8 n:1 0ms
 2017-02-16T11:59:49.706-0800 [conn9] groupCommit end
 2017-02-16T11:59:49.706-0800 [conn9] mmf close /var/folders/lm/b1r2f8p503xg40r6x2rqv7fr0000gp/T/mongo-eqCGuU/new2.ns
 2017-02-16T11:59:49.706-0800 [conn9] _groupCommit
 2017-02-16T11:59:49.706-0800 [conn9] journal REMAPPRIVATEVIEW
 2017-02-16T11:59:49.706-0800 [conn9] journal REMAPPRIVATEVIEW done startedAt: 9 n:1 0ms
 2017-02-16T11:59:49.706-0800 [conn9] groupCommit end
 2017-02-16T11:59:49.708-0800 [conn9] remove file /var/folders/lm/b1r2f8p503xg40r6x2rqv7fr0000gp/T/mongo-eqCGuU/new2.ns
 2017-02-16T11:59:49.708-0800 [conn9] dropDatabase new2 finished
 2017-02-16T11:59:49.708-0800 [conn9] command new2.$cmd command: dropDatabase { dropDatabase: 1 } keyUpdates:0 numYields:0 locks(micros) W:27437 reslen:55 27ms
 2017-02-16T11:59:49.708-0800 [conn8] checking size file /var/folders/lm/b1r2f8p503xg40r6x2rqv7fr0000gp/T/mongo-eqCGuU/local.ns
 2017-02-16T11:59:49.708-0800 [conn8] checking size file /var/folders/lm/b1r2f8p503xg40r6x2rqv7fr0000gp/T/mongo-eqCGuU/new.ns
 2017-02-16T11:59:49.708-0800 [conn8] opening db:  new2
```
Explaination:
1) dropDatabase: `new2` starts on `conn9`
2) listDatabase starts on `conn8` and sees that `new2` exists
3) dropDatabase: `new2` finishes on `conn9`
4) listDatabases continues  on `conn8` and recreates the `new2` database