### PR TITLE
Bug fix: all clients should inherit URI options

### DIFF
--- a/tests/test_mongo_connector.py
+++ b/tests/test_mongo_connector.py
@@ -70,6 +70,15 @@ class TestMongoConnector(unittest.TestCase):
         for thread in conn.shard_set.values():
             self.assertFalse(thread.running)
 
+    def test_copy_uri_options(self):
+        """Test copy_uri_options returns proper MongoDB URIs."""
+        uri = 'mongodb://host:27017/db?maxPoolSize=1234&w=2'
+        self.assertEqual(Connector.copy_uri_options('a:123,[::1]:321', uri),
+                         'mongodb://a:123,[::1]:321/?maxPoolSize=1234&w=2')
+        uri = 'host:27017'
+        self.assertEqual(Connector.copy_uri_options('a:123,[::1]:321', uri),
+                         'mongodb://a:123,[::1]:321')
+
     def test_write_oplog_progress(self):
         """Test write_oplog_progress under several circumstances
         """


### PR DESCRIPTION
This change passes [MongoDB URI options](https://docs.mongodb.com/manual/reference/connection-string/#connection-string-options) from the main address to clients created for each replica set shard. For example, with
```
$ mongo-connector -m 'mongodb://mongos:27017/?readPreference=primaryPreferred' ...
```
the `readPreference=primaryPreferred` option will be passed to all clients.