### PR TITLE
ImportError may contain relevant information

### DIFF
--- a/mongo_connector/connector.py
+++ b/mongo_connector/connector.py
@@ -966,18 +966,16 @@ def get_config_options():
                 if not issubclass(dm_impl, DocManagerBase):
                     raise TypeError("DocManager must inherit DocManagerBase.")
                 return dm_impl
-            except ImportError:
+            except ImportError as exc:
                 raise errors.InvalidConfiguration(
                     "Could not import %s. It could be that this doc manager ha"
                     "s been moved out of this project and is maintained elsewh"
                     "ere. Make sure that you have the doc manager installed al"
                     "ongside mongo-connector. Check the README for a list of a"
-                    "vailable doc managers." % package)
-                sys.exit(1)
+                    "vailable doc managers. ImportError:\n%s" % (package, exc))
             except (AttributeError, TypeError):
                 raise errors.InvalidConfiguration(
                     "No definition for DocManager found in %s." % package)
-                sys.exit(1)
 
         # instantiate the doc manager objects
         dm_instances = []


### PR DESCRIPTION
This change outputs the ImportError when attempting to import a DocManager. The ImportError may contain what the actually problem and solution is. For example, if mongo-connector and elastic2-doc-manager are installed but elasticsearch-py is missing:
```
$ mongo-connector -c configs/es.json --stdout
Traceback (most recent call last):
  File "/Users/shane/git/mongo-connector/venv-python2.6/bin/mongo-connector", line 11, in <module>
    sys.exit(main())
  File "/Users/shane/git/mongo-connector/venv-python2.6/lib/python2.6/site-packages/mongo_connector/util.py", line 104, in wrapped
    func(*args, **kwargs)
  File "/Users/shane/git/mongo-connector/venv-python2.6/lib/python2.6/site-packages/mongo_connector/connector.py", line 1249, in main
    conf.parse_args()
  File "/Users/shane/git/mongo-connector/venv-python2.6/lib/python2.6/site-packages/mongo_connector/config.py", line 120, in parse_args
    option, dict((k, values.get(k)) for k in option.cli_names))
  File "/Users/shane/git/mongo-connector/venv-python2.6/lib/python2.6/site-packages/mongo_connector/connector.py", line 986, in apply_doc_managers
    DocManager = import_dm_by_name(dm['docManager'])
  File "/Users/shane/git/mongo-connector/venv-python2.6/lib/python2.6/site-packages/mongo_connector/connector.py", line 958, in import_dm_by_name
    return import_dm_by_path(full_name)
  File "/Users/shane/git/mongo-connector/venv-python2.6/lib/python2.6/site-packages/mongo_connector/connector.py", line 975, in import_dm_by_path
    "vailable doc managers. ImportError:\n%s" % (package, exc))
mongo_connector.errors.InvalidConfiguration: Could not import mongo_connector.doc_managers.elastic2_doc_manager. It could be that this doc manager has been moved out of this project and is maintained elsewhere. Make sure that you have the doc manager installed alongside mongo-connector. Check the README for a list of available doc managers. ImportError:
Error: elasticsearch (https://pypi.python.org/pypi/elasticsearch) version 2.x or 5.x is not installed.
Install with:
  pip install elastic-doc-manager[elastic2]
or:
  pip install elastic-doc-manager[elastic5]
```

See https://github.com/mongodb-labs/mongo-connector/issues/644.