### PR TITLE
Upgrade Travis to latest MongoDB versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,9 @@ matrix:
   fast_finish: true
   include:
     - python: 2.6
-      env: MONGODB=3.4.0
+      env: MONGODB=3.4.2
     - python: 2.7
-      env: MONGODB=3.2.11
+      env: MONGODB=3.2.12
     - python: 3.3
       env: MONGODB=3.0.14
     - python: 3.4


### PR DESCRIPTION
We can change our Travis file to automatically download the lastest MongoDB versions once  MongoDB 2.4, 2.6, and 3.4 are added to the Travis whitelist (3.0 and 3.2 are already whitelisted). 

Adding 3.4 here: https://github.com/travis-ci/apt-source-whitelist/pull/348