### PR TITLE
Implement #728 Flush doc managers before oplog progress write

### DIFF
--- a/mongo_connector/connector.py
+++ b/mongo_connector/connector.py
@@ -241,6 +241,12 @@ class Connector(threading.Thread):
         if not items:
             return
 
+        # ensure DocManagers have completed operations before recording oplog
+        # progress
+
+        for dm in self.doc_managers:
+            dm.flush()
+
         # write to temp file
         backup_file = self.oplog_checkpoint + '.backup'
         os.rename(self.oplog_checkpoint, backup_file)

--- a/mongo_connector/doc_managers/doc_manager_base.py
+++ b/mongo_connector/doc_managers/doc_manager_base.py
@@ -163,6 +163,9 @@ class DocManagerBase(object):
         """
         raise NotImplementedError
 
+    def flush(self):
+        """Flush all outstanding writes."""
+
     def commit(self):
         """Commit all outstanding writes."""
         raise NotImplementedError

--- a/tests/test_mongo_connector.py
+++ b/tests/test_mongo_connector.py
@@ -34,7 +34,9 @@ from mongo_connector.version import Version
 from tests import unittest, SkipTest
 
 class AsyncDocManagerExample(DocManagerBase):
-    flush_occurred = False
+    def __init__(self):
+        self.flush_occurred = False
+
     def flush(self):
         self.flush_occurred = True
 

--- a/tests/test_mongo_connector.py
+++ b/tests/test_mongo_connector.py
@@ -24,6 +24,7 @@ from bson.timestamp import Timestamp
 
 sys.path[0:0] = [""]
 
+from mongo_connector.doc_managers.doc_manager_base import DocManagerBase
 from mongo_connector.connector import Connector, get_mininum_mongodb_version
 from mongo_connector.test_utils import (ReplicaSetSingle, connector_opts,
                                         assert_soon, db_user, db_password)
@@ -32,6 +33,13 @@ from mongo_connector.version import Version
 
 from tests import unittest, SkipTest
 
+class AsyncDocManagerExample(DocManagerBase):
+    flush_occurred = False
+    def flush(self):
+        self.flush_occurred = True
+
+    def flush_did_occur(self):
+        return self.flush_occurred
 
 class TestMongoConnector(unittest.TestCase):
     """ Test Class for the Mongo Connector
@@ -83,6 +91,24 @@ class TestMongoConnector(unittest.TestCase):
         uri = 'host:27017'
         self.assertEqual(Connector.copy_uri_options('a:123,[::1]:321', uri),
                          'mongodb://a:123,[::1]:321')
+
+    def test_write_oplog_progress_flushes_doc_managers(self):
+        """Test that write_oplog_progress flushes doc managers
+        """
+        async_docman = AsyncDocManagerExample()
+
+        conn = Connector(
+            mongo_address=self.repl_set.uri,
+            oplog_checkpoint="temp_oplog.timestamp",
+            doc_managers = [async_docman],
+            **connector_opts
+        )
+
+        # pretend to insert a thread/timestamp pair
+        conn.oplog_progress.get_dict()[1] = Timestamp(12, 34)
+        conn.write_oplog_progress()
+
+        self.assertEqual(async_docman.flush_did_occur(), True)
 
     def test_write_oplog_progress(self):
         """Test write_oplog_progress under several circumstances


### PR DESCRIPTION
This is my proposal for issue #728. Basically it gives us the ability to use an async or buffering doc manager (such as kafka) and ensure that writes are sent prior to writing oplog progress.

In our Kafka Doc Manager, the implementation essentially looks like:
```
def flush(self):
  self.producer.flush()
```

It is a different purpose than `commit()`, because with an async or buffering doc manager data can be lost without the flush()