### PR TITLE
Format UUID was set the same UUID into __id and UUID into document

### DIFF
--- a/mongo_connector/doc_managers/formatters.py
+++ b/mongo_connector/doc_managers/formatters.py
@@ -87,7 +87,7 @@ class DefaultDocumentFormatter(DocumentFormatter):
             # Just include body of binary data without subtype
             return base64.b64encode(value).decode()
         elif isinstance(value, UUID):
-            return value.hex
+            return value
         elif isinstance(value, (int, long, float)):
             if isnan(value):
                 raise ValueError("nan")

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -65,7 +65,7 @@ class TestFormatters(unittest.TestCase):
         self.assertEqual(trans(self.date), self.date)
 
         # UUID
-        self.assertEqual(trans(self.xuuid), self.xuuid.hex)
+        self.assertEqual(trans(self.xuuid), self.xuuid)
 
         # Other type
         self.assertEqual(trans(self.oid), str(self.oid))


### PR DESCRIPTION
Format UUID was set the same for DBRef, UUID into__id and UUID into document.
Now there are two different approachs how the mongo-connector handles UUID.
The first approach looks like into elastic2_doc_manager, doc-manager sets UUID into Elasticsearch as is, using default str method (with '-' delimiters)
The second approach looks like as into formatter, mongo-connector get hex value (without delimiters).
So we have different behaviors if we work with __id or UUID into doc.
It is unexpected behavior so we have to fix this.