### PR TITLE
Use update_one instead of findAndModify for update operations

### DIFF
--- a/mongo_connector/doc_managers/mongo_doc_manager.py
+++ b/mongo_connector/doc_managers/mongo_doc_manager.py
@@ -171,14 +171,11 @@ class DocManager(DocManagerBase):
              "_ts": timestamp,
              "ns": namespace},
             upsert=True)
-
-        no_obj_error = "No matching object found"
-        updated = self.mongo[db].command(
-            SON([('findAndModify', coll),
-                 ('query', {'_id': document_id}),
-                 ('update', update_spec),
-                 ('new', True)]),
-            allowable_errors=[no_obj_error])['value']
+        
+        if( "$set" not in update_spec and "$unset" not in update_spec ):
+            update_spec = {"$set": update_spec} # python requires a dollar sign operator
+        updated = self.mongo[db][coll].update_one({'_id': document_id}, update_spec )        
+        
         return updated
 
     @wrap_exceptions


### PR DESCRIPTION
findAndModify requires shard key, for update oplog with _id as the  the query key and without shard key, findAndModify will fail. Also the main difference between findAndModify & update is the return value. Currently the return value is not being used hence changed to use update_one instead. 