### PR TITLE
Added ability to access mongo oplog via mongos router/proxy

### DIFF
--- a/mongo_connector/connector.py
+++ b/mongo_connector/connector.py
@@ -384,6 +384,13 @@ class Connector(threading.Thread):
                 self.main_conn = self.create_authed_client(
                     replicaSet=is_master['setName'])
                 self.update_version_from_client(self.main_conn)
+            else:
+                try:
+                    # Check if local.oplog.rs is readable
+                    self.main_conn.local.oplog.rs.find_one()
+                except pymongo.errors.OperationFailure:
+                    LOG.error('Could not read local.oplog.rs!')
+                    sys.exit(1)
 
             # non sharded configuration
             oplog = OplogThread(


### PR DESCRIPTION
Fixes #390 

Added a new flag ```--is_oplog_proxy``` which tells the mongo connector to access oplog via the URI passed in. mongo_connector does not connect to individual shards directly to access mongo oplog.

```mongo-connector -m <IP_ADDRESS>:<PORT> -a <USER> -p <PASS> --ssl-ca-certs=op.pem -t <ELASTIC_DESTINATION> -d elastic2_doc_manager  --is_oplog_proxy=True```