### PR TITLE
Fix username clobbering in mongodb_uri

### DIFF
--- a/mongo_connector/connector.py
+++ b/mongo_connector/connector.py
@@ -311,10 +311,19 @@ class Connector(threading.Thread):
         """Returns a MongoDB URI to hosts with the options from mongodb_uri.
         """
         if '?' in mongodb_uri:
-            options = mongodb_uri.split('?', 1)[1]
+            base_url, options = mongodb_uri.split('?', 1)
         else:
-            options = None
-        uri = 'mongodb://' + hosts
+            base_url, options = '', None
+
+        # Parse out username and/or passwords from mongodb uri
+        if '@' in base_url:
+            auth_key = base_url.split('@')[0] + '@'
+            if auth_key.startswith('mongodb://'):
+                auth_key = auth_key[10:]
+        else:
+            auth_key = ''
+
+        uri = 'mongodb://' + auth_key + hosts
         if options:
             uri += '/?' + options
         return uri


### PR DESCRIPTION
I was unable to get mongo-connector to authenticate with mongodb as the origin using x509 auth.  When calling with username on the command line, i.e.,

    mongo-connector --admin-username <X.509 derived username> -m mongodb://localhost/?replicaSet=rs&authMechanism=MONGODB-X509&authSource=$external&ssl=true&ssl_certfile=/etc/pki/tls/private/bundle.pem

mongo complains `mongo_connector.errors.InvalidConfiguration: Admin username specified without password.`

When calling with the username as part of the mongo uri, i.e.,

    mongo-connector -m mongodb://<X.509 derived username>@localhost/?replicaSet=rs&authMechanism=MONGODB-X509&authSource=$external&ssl=true&ssl_certfile=/etc/pki/tls/private/bundle.pem

the username gets clobbered by `connection.copy_uri_options()` and the server rejects the connection.

This PR updates `connection.copy_uri_options()` to not clobber usernames and passwords. I haven't tested it with anonymous or any other type of authentication, but I believe it should work.

Note, using x509 auth with mongo as the destination db does not have this bug.