### PR TITLE
Catching the hidden duplicate key errors

### DIFF
--- a/mongo_connector/doc_managers/mongo_doc_manager.py
+++ b/mongo_connector/doc_managers/mongo_doc_manager.py
@@ -239,8 +239,10 @@ class DocManager(DocManagerBase):
                 LOG.warn('Continuing after DuplicateKeyError: '
                          + str(e))
             except pymongo.errors.BulkWriteError as bwe:
-                LOG.error(bwe.details)
-                raise e
+                for writeError in bwe.details['writeErrors']:
+                    if writeError['code'] != 11000:
+                        raise bwe
+                pass
 
     @wrap_exceptions
     def remove(self, document_id, namespace, timestamp):


### PR DESCRIPTION
There's an except for DuplicateKeyError, but bulk_op.execute will only throw BulkWriteError with the dup key error inside of it.  Add a loop through the bulk write error details to pass if the only errors are duplicate key errors.